### PR TITLE
feat: add SEO backlink profile copy for 18 platforms

### DIFF
--- a/tasks/seo-backlink-profiles.md
+++ b/tasks/seo-backlink-profiles.md
@@ -1,0 +1,335 @@
+# SEO Backlink Profile Copy — CounterbenchAI
+
+> Ready-to-paste profile text for 18 platforms. Optimized for **"AI paralegal tools"** and **"legal AI for paralegals"**.
+> Do NOT create accounts or publish without Philipp's approval.
+
+---
+
+## 1. Crunchbase
+
+**Company Name:** CounterbenchAI
+**Short Description (max 140 chars):**
+AI paralegal tools platform — 275+ legal AI tools, 800+ prompts, and workflow playbooks for paralegals and law firms.
+
+**Full Description:**
+CounterbenchAI is a curated legal AI directory and resource platform built for paralegals and law firms. The platform features 275+ reviewed legal AI tools, 800+ ready-to-use prompts for legal tasks, 30+ workflow skills, and 10+ practice playbooks. Paralegals use CounterbenchAI to find the right AI tools for their practice area, streamline document review, and build efficient legal workflows. Collections span 11+ practice areas including contract analysis, litigation support, compliance, and e-discovery.
+
+**Website:** https://counterbench.ai
+**Categories:** Legal Tech, Artificial Intelligence, SaaS
+**Headquarters:** Boston, MA
+
+**Formatting Notes:**
+- Crunchbase enforces a 140-char limit on short descriptions — keep it tight.
+- Full description supports plain text only (no markdown, no links).
+- Add founders, funding stage, and employee count if applicable.
+
+---
+
+## 2. Medium
+
+**Display Name:** CounterbenchAI
+**Bio (max 160 chars):**
+AI paralegal tools & legal AI for paralegals. 275+ tools, 800+ prompts, workflow playbooks. Find the right legal AI — fast. counterbench.ai
+
+**Formatting Notes:**
+- Bio appears under the profile name. No markdown, no clickable links in bio text — URL renders as plain text.
+- Use the publication feature to create a branded publication for long-form content.
+- First article should link back to counterbench.ai naturally within the content body.
+
+---
+
+## 3. Substack
+
+**Publication Name:** CounterbenchAI
+**One-line Description:**
+AI paralegal tools, legal AI reviews, and workflow guides for paralegals and law firms.
+
+**About Page Copy:**
+CounterbenchAI is a curated directory of 275+ legal AI tools, 800+ ready-to-use prompts, and practice playbooks built for paralegals. We review, categorize, and compare AI tools so paralegals can find what actually works — without the marketing noise. Topics include AI-assisted document review, contract analysis, legal research automation, and practice-area-specific AI workflows.
+
+Subscribe for weekly reviews of legal AI tools, prompt templates for common paralegal tasks, and practical guides to building AI-powered legal workflows.
+
+**Website Link:** https://counterbench.ai
+
+**Formatting Notes:**
+- Substack supports rich text in the About page. Keep it scannable.
+- The one-line description appears in search results and recommendations — front-load keywords.
+- Set the custom domain or at minimum add the website link in settings.
+
+---
+
+## 4. Reddit
+
+**Display Name:** CounterbenchAI
+**About / Bio (max 200 chars):**
+Curated directory of 275+ AI paralegal tools, 800+ legal AI prompts, and workflow playbooks. Helping paralegals find the right AI tools. counterbench.ai
+
+**Formatting Notes:**
+- Reddit bios are plain text, 200-char limit.
+- Do NOT use the profile for self-promotion posts — Reddit's spam filters are aggressive.
+- Engage authentically in r/paralegal, r/legaltech, r/LawFirm, r/artificial before any link sharing.
+- Profile serves as credibility anchor when commenting, not as a landing page.
+
+---
+
+## 5. Pinterest
+
+**Display Name:** CounterbenchAI
+**About (max 500 chars):**
+AI paralegal tools and legal AI resources for paralegals, legal assistants, and law firms. CounterbenchAI is a curated directory of 275+ reviewed legal AI tools, 800+ ready-to-use prompts, 30+ workflow skills, and 10+ practice playbooks. We help paralegals find, compare, and use the best AI tools for document review, contract analysis, legal research, and more. Visit counterbench.ai for the full directory.
+
+**Website:** https://counterbench.ai
+
+**Formatting Notes:**
+- Pinterest is visual — create boards like "AI Tools for Paralegals," "Legal AI Prompts," "Contract Review AI."
+- Pin descriptions support hashtags: #AIParalegalTools #LegalAI #ParalegalTools #LegalTech
+- Website field creates a verified backlink. Claim the website in Pinterest settings for link attribution.
+
+---
+
+## 6. Quora
+
+**Profile Credentials:** Legal AI Tools | CounterbenchAI
+**Bio:**
+Founder of CounterbenchAI — a curated directory of 275+ AI paralegal tools, 800+ legal AI prompts, and workflow playbooks for paralegals and law firms. I write about how paralegals can use AI tools to streamline document review, contract analysis, and legal research workflows. counterbench.ai
+
+**Formatting Notes:**
+- Quora bios support plain text with a clickable URL at the end.
+- Credentials appear next to every answer — use "Legal AI Tools" or "AI Paralegal Tools" as the topic credential.
+- Answers should provide genuine value. Link to counterbench.ai only when directly relevant.
+- Create a Quora Space for "Legal AI for Paralegals" if the topic isn't saturated.
+
+---
+
+## 7. Tumblr
+
+**Blog Title:** CounterbenchAI
+**Blog Description:**
+AI paralegal tools directory — 275+ legal AI tools reviewed and categorized for paralegals. Prompts, workflow playbooks, and practice-area guides for legal professionals using AI. counterbench.ai
+
+**Formatting Notes:**
+- Tumblr supports HTML in blog descriptions. Can bold key phrases if desired.
+- Posts support rich media — use for infographics about legal AI tools.
+- Tag posts with: #legal ai, #paralegal tools, #ai for paralegals, #legal tech, #ai paralegal tools
+- The blog URL (counterbenchai.tumblr.com) itself provides a dofollow backlink in the description.
+
+---
+
+## 8. Blogger
+
+**Blog Title:** CounterbenchAI — AI Paralegal Tools & Legal AI Resources
+**Blog Description:**
+CounterbenchAI is a curated legal AI directory featuring 275+ reviewed AI tools for paralegals, 800+ ready-to-use legal prompts, and workflow playbooks. We help paralegals and law firms find, compare, and implement AI tools for document review, contract analysis, e-discovery, and legal research. Visit the full directory at counterbench.ai.
+
+**Formatting Notes:**
+- Blogger supports HTML in the "About" widget. Add a hyperlink to counterbench.ai.
+- Blog description appears in search results — keep target keywords front-loaded.
+- Google indexes Blogger content well — publish at least one substantive post linking back to the main site.
+- Use the blogspot subdomain or connect a custom domain.
+
+---
+
+## 9. About.me
+
+**Headline:** AI Paralegal Tools — CounterbenchAI
+**Bio:**
+I built CounterbenchAI to solve a simple problem: paralegals shouldn't have to wade through hundreds of AI tools to find the ones that actually work for legal tasks. CounterbenchAI is a curated directory of 275+ reviewed legal AI tools, 800+ ready-to-use prompts, and 10+ practice playbooks. Whether you're looking for AI-assisted contract review, legal research tools, or workflow automation, we've done the vetting so you don't have to.
+
+**Website:** https://counterbench.ai
+
+**Formatting Notes:**
+- About.me supports one primary website link (prominent, dofollow).
+- Headline is the most visible text — use primary keywords.
+- Bio supports plain text only. Keep it personal (first person) per platform convention.
+- Add social links to other profiles created from this list for cross-linking.
+
+---
+
+## 10. Scribd
+
+**Publisher Name:** CounterbenchAI
+**Bio:**
+CounterbenchAI publishes guides, checklists, and resources on AI paralegal tools and legal AI for paralegals. Our curated directory features 275+ reviewed legal AI tools, 800+ prompts, and practice playbooks. Find us at counterbench.ai.
+
+**Formatting Notes:**
+- Scribd profiles gain authority through uploaded documents (PDFs, presentations).
+- Upload: "Top 10 AI Tools for Paralegals (2026)," prompt template PDFs, or workflow guides.
+- Documents can contain links back to counterbench.ai — Scribd has high domain authority.
+- Bio supports plain text. Publisher name appears in search results.
+
+---
+
+## 11. SlideShare
+
+**Display Name:** CounterbenchAI
+**Bio:**
+AI paralegal tools and legal AI resources. CounterbenchAI is a curated directory of 275+ legal AI tools, 800+ prompts, and practice playbooks for paralegals and law firms. counterbench.ai
+
+**Formatting Notes:**
+- SlideShare (now owned by Scribd) indexes presentations well in Google.
+- Upload slide decks: "AI Tools Every Paralegal Should Know," "Legal AI Workflow Guide."
+- Presentation descriptions support links — include counterbench.ai with keyword-rich anchor text.
+- Tags: AI paralegal tools, legal AI, paralegal technology, legal tech, AI for law firms.
+
+---
+
+## 12. Manta
+
+**Business Name:** CounterbenchAI
+**Description:**
+CounterbenchAI is a legal AI tools platform that provides paralegals and law firms with a curated directory of 275+ AI tools, 800+ ready-to-use prompts, and workflow playbooks. Our platform helps legal professionals find, compare, and implement AI paralegal tools for document review, contract analysis, legal research, and practice management.
+
+**Category:** Technology / Software
+**Website:** https://counterbench.ai
+
+**Formatting Notes:**
+- Manta is a business directory — treat this as a local business listing.
+- Description supports plain text. Front-load with "legal AI tools" and "AI paralegal tools."
+- Add business hours, location (Boston, MA), and contact info if desired.
+- Manta listings get indexed by Google and provide a dofollow backlink.
+
+---
+
+## 13. Yelp
+
+**Business Name:** CounterbenchAI
+**Business Description:**
+CounterbenchAI is an AI tools platform for paralegals and law firms. We maintain a curated directory of 275+ reviewed legal AI tools, 800+ ready-to-use prompts for legal tasks, and practice-area playbooks. Paralegals use our platform to find the best AI tools for document review, contract analysis, and legal research workflows.
+
+**Category:** Software Development, Information Technology
+**Website:** https://counterbench.ai
+
+**Formatting Notes:**
+- Yelp is primarily for local businesses, but tech companies can list.
+- Select "Software Development" or "Information Technology" as the category.
+- Description supports plain text only. Keep it factual — Yelp filters promotional language.
+- Yelp has high domain authority — even a basic listing provides SEO value.
+- Do NOT solicit reviews — Yelp penalizes this aggressively.
+
+---
+
+## 14. Framer
+
+**Portfolio/Site Title:** CounterbenchAI
+**Bio / About:**
+AI paralegal tools platform. 275+ curated legal AI tools, 800+ prompts, and workflow playbooks for paralegals and law firms. Built to help legal professionals find the right AI — fast.
+
+**Website Link:** https://counterbench.ai
+
+**Formatting Notes:**
+- Framer is a design/portfolio platform. Use it for a simple landing page or portfolio linking back to counterbench.ai.
+- The profile itself provides a backlink. A published Framer site adds a second indexed page.
+- Keep the page minimal — a one-page overview of CounterbenchAI with a CTA to the main site.
+- Framer sites are indexed by Google and can rank independently.
+
+---
+
+## 15. Patreon
+
+**Page Name:** CounterbenchAI
+**About / Description:**
+CounterbenchAI is a curated legal AI directory with 275+ tools, 800+ prompts, and practice playbooks built for paralegals. We review and categorize AI paralegal tools so legal professionals can find what works without the noise.
+
+Support us to get early access to new tool reviews, exclusive prompt libraries, and behind-the-scenes looks at how we evaluate legal AI tools for paralegals.
+
+**Website:** https://counterbench.ai
+
+**Formatting Notes:**
+- Patreon supports rich text and images in the About section.
+- The page doesn't need active tiers to provide backlink value — but adding at least one free tier looks more legitimate.
+- Tag the page with relevant categories: Technology, Education, Software.
+- Link to counterbench.ai in the About section — this is a dofollow link.
+
+---
+
+## 16. Business2Community
+
+**Author/Contributor Bio:**
+[Author Name] is the founder of CounterbenchAI, a curated directory of 275+ AI paralegal tools, 800+ legal AI prompts, and practice playbooks. CounterbenchAI helps paralegals and law firms find, compare, and implement the right AI tools for document review, contract analysis, and legal research. Learn more at counterbench.ai.
+
+**Formatting Notes:**
+- Business2Community is a contributor platform — apply as a contributor/author.
+- Author bios typically appear at the bottom of articles with a link to your site.
+- Write articles about legal AI trends, AI paralegal tools comparisons, or legal tech adoption.
+- The backlink comes from the author bio, not the article body (editorial links in body are bonus).
+- High domain authority site — contributor backlinks carry significant SEO weight.
+
+---
+
+## 17. Viralmarketinglab
+
+**Profile/Bio:**
+CounterbenchAI — AI paralegal tools platform featuring 275+ curated legal AI tools, 800+ ready-to-use prompts, and workflow playbooks for paralegals and law firms. We help legal professionals find the right AI tools for document review, contract analysis, and legal research. counterbench.ai
+
+**Formatting Notes:**
+- Smaller platform — primary value is the indexed backlink.
+- Keep the profile factual and keyword-rich.
+- If the platform supports articles or posts, publish one substantive piece linking to counterbench.ai.
+- Monitor for platform changes — smaller directories sometimes go offline or change policies.
+
+---
+
+## 18. Craigslist
+
+**Post Title:** AI Paralegal Tools — Free Legal AI Directory for Paralegals & Law Firms
+**Post Body:**
+CounterbenchAI is a free, curated directory of 275+ AI tools built for paralegals and law firms.
+
+What's included:
+- 275+ reviewed legal AI tools across 11+ practice areas
+- 800+ ready-to-use prompts for legal tasks
+- 30+ workflow skills and 10+ practice playbooks
+- Interactive tools: contract QA planner, source finder, and more
+
+Whether you need AI for document review, contract analysis, legal research, or compliance — we've reviewed and categorized the tools so you can find what works.
+
+Browse the full directory: counterbench.ai
+
+**Category:** Services > Computer
+**Location:** Boston, MA
+
+**Formatting Notes:**
+- Craigslist posts are temporary (expire after ~30-45 days depending on category).
+- No dofollow backlinks — Craigslist nofollows all links. Value is in traffic and brand visibility.
+- Post in "Services > Computer" or "Community > General" depending on intent.
+- Do NOT post in multiple cities — Craigslist flags duplicate posts as spam.
+- Keep the tone informational, not salesy — Craigslist users flag overtly promotional posts.
+- Repost periodically (after expiration) for ongoing visibility.
+
+---
+
+## Target Keywords Reference
+
+These keywords should appear naturally across all profiles:
+
+| Primary Keywords | Secondary Keywords |
+|---|---|
+| AI paralegal tools | legal AI directory |
+| legal AI for paralegals | AI tools for law firms |
+| | paralegal AI prompts |
+| | legal AI workflow |
+| | AI document review for paralegals |
+| | contract analysis AI |
+
+## Backlink Quality Notes
+
+| Platform | DA (approx.) | Link Type | Priority |
+|---|---|---|---|
+| Crunchbase | 90+ | Dofollow | High |
+| Medium | 95+ | Nofollow | High (traffic) |
+| Substack | 90+ | Dofollow | High |
+| Reddit | 99 | Nofollow | High (traffic + credibility) |
+| Pinterest | 95+ | Nofollow | Medium |
+| Quora | 93 | Nofollow | High (traffic) |
+| Tumblr | 80+ | Dofollow | Medium |
+| Blogger | 95+ | Dofollow | High |
+| About.me | 90+ | Dofollow | High |
+| Scribd | 90+ | Dofollow | High |
+| SlideShare | 90+ | Dofollow | High |
+| Manta | 70+ | Dofollow | Medium |
+| Yelp | 93 | Nofollow | Medium |
+| Framer | 70+ | Dofollow | Medium |
+| Patreon | 90+ | Dofollow | High |
+| Business2Community | 80+ | Dofollow | High |
+| Viralmarketinglab | 30+ | Varies | Low |
+| Craigslist | 95+ | Nofollow | Low (temporary) |


### PR DESCRIPTION
## Summary
- Adds ready-to-paste SEO backlink profile copy for 18 platforms (Crunchbase, Medium, Substack, Reddit, Pinterest, Quora, Tumblr, Blogger, About.me, Scribd, SlideShare, Manta, Yelp, Framer, Patreon, Business2Community, Viralmarketinglab, Craigslist)
- All copy optimized for target keywords: "AI paralegal tools" and "legal AI for paralegals"
- Includes platform-specific formatting notes, character limits, and best practices
- Includes backlink quality reference table (DA estimates, link types, priority ranking)

## Notes
- No accounts created, nothing published — copy only
- Product claims verified against actual features (275+ tools, 800+ prompts, 30+ skills, 10+ playbooks)
- Output file: `tasks/seo-backlink-profiles.md`

## Test plan
- [x] Verify all 18 platforms are covered
- [x] Verify keyword optimization in each profile
- [x] Verify product claims match actual CounterbenchAI features
- [x] Verify platform-specific formatting notes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)