### PR TITLE
feat: set up Stripe for workshop ticket sales (3 tiers + early bird)

### DIFF
--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { getStripe } from "@/lib/stripe/client";
+import { WORKSHOP_TIERS } from "@/lib/stripe/workshop-products";
+
+export async function POST(req: Request) {
+  const body = (await req.json().catch(() => null)) as {
+    tierKey?: string;
+    earlyBird?: boolean;
+  } | null;
+
+  if (!body?.tierKey) {
+    return NextResponse.json(
+      { error: "Missing tierKey" },
+      { status: 400 }
+    );
+  }
+
+  const tier = WORKSHOP_TIERS.find((t) => t.key === body.tierKey);
+  if (!tier) {
+    return NextResponse.json(
+      { error: "Invalid tier" },
+      { status: 400 }
+    );
+  }
+
+  const priceId = body.earlyBird ? tier.earlyBirdPriceId : tier.priceId;
+  if (!priceId) {
+    return NextResponse.json(
+      { error: "Stripe prices not configured yet. Run the setup script first." },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const stripe = getStripe();
+
+    const origin =
+      req.headers.get("origin") ||
+      process.env.NEXT_PUBLIC_SITE_URL ||
+      "https://counterbench.ai";
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${origin}/workshop/confirmation?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${origin}/workshop?canceled=true`,
+      metadata: {
+        workshop_tier: tier.key,
+        price_variant: body.earlyBird ? "early_bird" : "full",
+      },
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    console.error("[checkout] Stripe session creation failed:", err);
+    return NextResponse.json(
+      { error: "Failed to create checkout session" },
+      { status: 500 }
+    );
+  }
+}

--- a/docs/stripe-workshop-setup.md
+++ b/docs/stripe-workshop-setup.md
@@ -1,0 +1,86 @@
+# Stripe Workshop Ticket Setup
+
+## Overview
+
+Three workshop tiers with early-bird pricing ($100 off for first 10 registrants per tier).
+
+| Tier         | Full Price | Early Bird | Early Bird Cap |
+|-------------|-----------|------------|----------------|
+| Standard    | $597      | $497       | 10             |
+| Premium     | $897      | $797       | 10             |
+| Firm Package| $2,497    | $2,397     | 10             |
+
+## Setup Steps
+
+### 1. Run the setup script (creates products + prices in Stripe test mode)
+
+```bash
+STRIPE_SECRET_KEY=sk_test_YOUR_KEY npx tsx scripts/stripe-setup-workshop.ts
+```
+
+The script will:
+- Create 3 Stripe products (one per tier)
+- Create 2 prices per product (full + early-bird)
+- Output the price IDs
+
+The script is idempotent — safe to re-run.
+
+### 2. Copy the price IDs
+
+Take the output from the script and update `lib/stripe/workshop-products.ts` with the real `productId`, `priceId`, and `earlyBirdPriceId` values.
+
+### 3. Set environment variables
+
+```env
+# Stripe test mode keys
+STRIPE_SECRET_KEY=sk_test_...
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+
+# Optional: webhook secret (for order fulfillment later)
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+### 4. Test the checkout flow
+
+POST to `/api/checkout`:
+```json
+{
+  "tierKey": "standard",
+  "earlyBird": true
+}
+```
+
+Returns `{ "url": "https://checkout.stripe.com/..." }` — redirect the user there.
+
+## What's Created in Stripe
+
+### Products (3)
+Each product has metadata `workshop_tier` and `type: workshop_ticket`.
+
+- **CounterbenchAI Workshop — Standard**
+- **CounterbenchAI Workshop — Premium**
+- **CounterbenchAI Workshop — Firm Package**
+
+### Prices (6 total — 2 per product)
+Each price is one-time (not recurring), USD, with metadata `variant` (full/early_bird) and `workshop_tier`.
+
+## Early Bird Logic
+
+Early-bird tracking is not yet automated in code. Options:
+1. **Manual**: Track registrations per tier, switch `earlyBird: false` on the landing page after 10 sold
+2. **Automated**: Add a counter (database or Stripe metadata query) that checks purchase count before selecting the price — implement when the landing page is built
+
+## Going Live
+
+1. Re-run the setup script with your **live** Stripe key (`sk_live_...`) — the script will refuse non-test keys, so remove the safety check first
+2. Update env vars to live keys
+3. Set up a Stripe webhook for `checkout.session.completed` to handle order fulfillment (email confirmation, access provisioning)
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `lib/stripe/client.ts` | Server-side Stripe client singleton |
+| `lib/stripe/workshop-products.ts` | Tier config (prices, features, IDs) |
+| `scripts/stripe-setup-workshop.ts` | One-time Stripe product/price creation |
+| `app/api/checkout/route.ts` | Checkout session API endpoint |

--- a/lib/stripe/client.ts
+++ b/lib/stripe/client.ts
@@ -1,0 +1,22 @@
+import Stripe from "stripe";
+
+let _stripe: Stripe | null = null;
+
+/**
+ * Server-side Stripe client singleton.
+ * Requires STRIPE_SECRET_KEY in environment.
+ */
+export function getStripe(): Stripe {
+  if (_stripe) return _stripe;
+
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    throw new Error("STRIPE_SECRET_KEY is not set");
+  }
+
+  _stripe = new Stripe(key, {
+    apiVersion: "2026-02-25.clover",
+  });
+
+  return _stripe;
+}

--- a/lib/stripe/workshop-products.ts
+++ b/lib/stripe/workshop-products.ts
@@ -1,0 +1,87 @@
+/**
+ * Workshop ticket product & price configuration.
+ *
+ * Prices are one-time (not subscriptions).
+ * Early-bird discount: $100 off for the first 10 registrants per tier.
+ *
+ * After running `scripts/stripe-setup-workshop.ts`, replace the placeholder
+ * `priceId` / `earlyBirdPriceId` values with the real Stripe price IDs it outputs.
+ */
+
+export interface WorkshopTier {
+  key: string;
+  name: string;
+  /** Stripe product ID — populated after setup script runs */
+  productId: string;
+  /** Full-price Stripe price ID */
+  priceId: string;
+  /** Early-bird Stripe price ID ($100 off) */
+  earlyBirdPriceId: string;
+  /** Standard price in cents */
+  priceInCents: number;
+  /** Early-bird price in cents */
+  earlyBirdPriceInCents: number;
+  /** Max early-bird registrations before reverting to full price */
+  earlyBirdCap: number;
+  description: string;
+  features: string[];
+}
+
+export const WORKSHOP_TIERS: WorkshopTier[] = [
+  {
+    key: "standard",
+    name: "Standard",
+    productId: "", // TODO: populate after Stripe setup
+    priceId: "", // TODO: populate after Stripe setup
+    earlyBirdPriceId: "", // TODO: populate after Stripe setup
+    priceInCents: 59700,
+    earlyBirdPriceInCents: 49700,
+    earlyBirdCap: 10,
+    description: "Full workshop access",
+    features: [
+      "Full-day workshop access",
+      "Workshop materials & templates",
+      "Certificate of completion",
+    ],
+  },
+  {
+    key: "premium",
+    name: "Premium",
+    productId: "", // TODO: populate after Stripe setup
+    priceId: "", // TODO: populate after Stripe setup
+    earlyBirdPriceId: "", // TODO: populate after Stripe setup
+    priceInCents: 89700,
+    earlyBirdPriceInCents: 79700,
+    earlyBirdCap: 10,
+    description: "Workshop + extras",
+    features: [
+      "Everything in Standard",
+      "1-on-1 follow-up session",
+      "Priority Q&A access",
+      "Bonus resource pack",
+    ],
+  },
+  {
+    key: "firm",
+    name: "Firm Package",
+    productId: "", // TODO: populate after Stripe setup
+    priceId: "", // TODO: populate after Stripe setup
+    earlyBirdPriceId: "", // TODO: populate after Stripe setup
+    priceInCents: 249700,
+    earlyBirdPriceInCents: 239700,
+    earlyBirdCap: 10,
+    description: "Team access for your firm",
+    features: [
+      "Everything in Premium",
+      "Up to 5 team members",
+      "Firm-specific implementation plan",
+      "Dedicated support channel",
+      "Post-workshop consulting session",
+    ],
+  },
+];
+
+/** Format cents to display price string */
+export function formatPrice(cents: number): string {
+  return `$${(cents / 100).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "remark-gfm": "^4.0.0",
+        "stripe": "^20.4.1",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -1467,7 +1468,7 @@
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -7488,6 +7489,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
+      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7836,7 +7854,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -58,13 +58,14 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "remark-gfm": "^4.0.0",
+    "stripe": "^20.4.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
     "@types/node": "^22.13.5",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
-    "@playwright/test": "^1.55.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.0.0",
     "tsx": "^4.19.3",

--- a/scripts/stripe-setup-workshop.ts
+++ b/scripts/stripe-setup-workshop.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env tsx
+/**
+ * One-time setup script: creates Stripe products and prices for workshop tiers.
+ *
+ * Usage:
+ *   STRIPE_SECRET_KEY=sk_test_... npx tsx scripts/stripe-setup-workshop.ts
+ *
+ * This script is idempotent — it checks for existing products by metadata
+ * before creating new ones. Safe to re-run.
+ *
+ * After running, copy the output price IDs into lib/stripe/workshop-products.ts.
+ */
+
+import Stripe from "stripe";
+
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+if (!STRIPE_SECRET_KEY) {
+  console.error("Error: Set STRIPE_SECRET_KEY environment variable.");
+  console.error("  Use your TEST mode key (sk_test_...).");
+  process.exit(1);
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
+  apiVersion: "2026-02-25.clover",
+});
+
+interface TierSpec {
+  key: string;
+  name: string;
+  description: string;
+  priceInCents: number;
+  earlyBirdPriceInCents: number;
+}
+
+const TIERS: TierSpec[] = [
+  {
+    key: "standard",
+    name: "CounterbenchAI Workshop — Standard",
+    description: "Full-day workshop access with materials and certificate",
+    priceInCents: 59700,
+    earlyBirdPriceInCents: 49700,
+  },
+  {
+    key: "premium",
+    name: "CounterbenchAI Workshop — Premium",
+    description:
+      "Workshop access plus 1-on-1 follow-up, priority Q&A, and bonus resources",
+    priceInCents: 89700,
+    earlyBirdPriceInCents: 79700,
+  },
+  {
+    key: "firm",
+    name: "CounterbenchAI Workshop — Firm Package",
+    description:
+      "Team workshop access (up to 5), implementation plan, and consulting session",
+    priceInCents: 249700,
+    earlyBirdPriceInCents: 239700,
+  },
+];
+
+async function findExistingProduct(
+  key: string
+): Promise<Stripe.Product | null> {
+  const products = await stripe.products.search({
+    query: `metadata["workshop_tier"]:"${key}"`,
+  });
+  return products.data[0] ?? null;
+}
+
+async function setupTier(spec: TierSpec) {
+  console.log(`\n--- ${spec.name} ---`);
+
+  // Check for existing product
+  let product = await findExistingProduct(spec.key);
+
+  if (product) {
+    console.log(`  Product already exists: ${product.id}`);
+  } else {
+    product = await stripe.products.create({
+      name: spec.name,
+      description: spec.description,
+      metadata: {
+        workshop_tier: spec.key,
+        type: "workshop_ticket",
+      },
+    });
+    console.log(`  Created product: ${product.id}`);
+  }
+
+  // Find existing prices
+  const existingPrices = await stripe.prices.list({
+    product: product.id,
+    active: true,
+  });
+
+  let fullPrice = existingPrices.data.find(
+    (p) => p.unit_amount === spec.priceInCents && p.metadata.variant === "full"
+  );
+  let earlyBirdPrice = existingPrices.data.find(
+    (p) =>
+      p.unit_amount === spec.earlyBirdPriceInCents &&
+      p.metadata.variant === "early_bird"
+  );
+
+  // Create full price
+  if (fullPrice) {
+    console.log(`  Full price already exists: ${fullPrice.id}`);
+  } else {
+    fullPrice = await stripe.prices.create({
+      product: product.id,
+      unit_amount: spec.priceInCents,
+      currency: "usd",
+      metadata: {
+        variant: "full",
+        workshop_tier: spec.key,
+      },
+    });
+    console.log(`  Created full price: ${fullPrice.id}`);
+  }
+
+  // Create early-bird price
+  if (earlyBirdPrice) {
+    console.log(`  Early-bird price already exists: ${earlyBirdPrice.id}`);
+  } else {
+    earlyBirdPrice = await stripe.prices.create({
+      product: product.id,
+      unit_amount: spec.earlyBirdPriceInCents,
+      currency: "usd",
+      metadata: {
+        variant: "early_bird",
+        workshop_tier: spec.key,
+      },
+    });
+    console.log(`  Created early-bird price: ${earlyBirdPrice.id}`);
+  }
+
+  return {
+    key: spec.key,
+    productId: product.id,
+    priceId: fullPrice.id,
+    earlyBirdPriceId: earlyBirdPrice.id,
+    priceInCents: spec.priceInCents,
+    earlyBirdPriceInCents: spec.earlyBirdPriceInCents,
+  };
+}
+
+async function main() {
+  // Verify we're in test mode
+  if (!STRIPE_SECRET_KEY!.startsWith("sk_test_")) {
+    console.error(
+      "WARNING: This does not look like a test-mode key. Aborting."
+    );
+    console.error("  Use sk_test_... to create products in test mode.");
+    process.exit(1);
+  }
+
+  console.log("Setting up Stripe workshop products (TEST MODE)...\n");
+
+  const results = [];
+  for (const tier of TIERS) {
+    results.push(await setupTier(tier));
+  }
+
+  console.log("\n\n========================================");
+  console.log("SETUP COMPLETE — Copy these into lib/stripe/workshop-products.ts:");
+  console.log("========================================\n");
+
+  for (const r of results) {
+    console.log(`// ${r.key}`);
+    console.log(`productId: "${r.productId}",`);
+    console.log(
+      `priceId: "${r.priceId}",  // $${(r.priceInCents / 100).toFixed(0)}`
+    );
+    console.log(
+      `earlyBirdPriceId: "${r.earlyBirdPriceId}",  // $${(r.earlyBirdPriceInCents / 100).toFixed(0)} (early bird)`
+    );
+    console.log();
+  }
+
+  console.log("\nEnvironment variables needed:");
+  console.log("  STRIPE_SECRET_KEY=sk_test_...");
+  console.log("  NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...");
+  console.log(
+    "  STRIPE_WEBHOOK_SECRET=whsec_... (for webhook verification, set up later)"
+  );
+}
+
+main().catch((err) => {
+  console.error("Setup failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds Stripe SDK and creates the full integration scaffold for workshop ticket sales
- **3 tiers**: Standard ($597), Premium ($897), Firm Package ($2,497)
- **Early-bird pricing**: $100 off for first 10 registrants per tier ($497 / $797 / $2,397)
- Includes a one-time setup script (`scripts/stripe-setup-workshop.ts`) that creates products and prices in Stripe **test mode**
- Checkout API route at `/api/checkout` creates Stripe Checkout sessions
- All in test mode — nothing is live or published

## Files added

| File | Purpose |
|------|---------|
| `lib/stripe/client.ts` | Server-side Stripe client singleton |
| `lib/stripe/workshop-products.ts` | Tier config (prices, features, price IDs) |
| `scripts/stripe-setup-workshop.ts` | Idempotent Stripe product/price creation script |
| `app/api/checkout/route.ts` | Checkout session API endpoint |
| `docs/stripe-workshop-setup.md` | Full setup documentation |

## How to activate

```bash
STRIPE_SECRET_KEY=sk_test_... npx tsx scripts/stripe-setup-workshop.ts
```

Then copy the output price IDs into `lib/stripe/workshop-products.ts`.

## Test plan

- [ ] Run setup script with test Stripe key, verify products/prices created in Stripe Dashboard
- [ ] Verify script is idempotent (re-run doesn't create duplicates)
- [ ] POST to `/api/checkout` with `{ "tierKey": "standard", "earlyBird": true }`, verify redirect URL returned
- [ ] `npm run build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)