### PR TITLE
feat: workshop landing page at /workshops with city selector and Stripe checkout

### DIFF
--- a/app/(marketing)/workshops/[city]/[date]/page.tsx
+++ b/app/(marketing)/workshops/[city]/[date]/page.tsx
@@ -1,0 +1,272 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { EVENTS, TIERS, getCityInfo, getEvent, formatDate, hasEarlyBird } from "@/data/workshops";
+import { WorkshopCheckout } from "@/components/WorkshopCheckout";
+
+export function generateStaticParams() {
+  return EVENTS.map((e) => ({ city: e.citySlug, date: e.date }));
+}
+
+type Params = { city: string; date: string };
+
+export async function generateMetadata({ params }: { params: Promise<Params> }) {
+  const { city: citySlug, date } = await params;
+  const city = getCityInfo(citySlug);
+  const event = getEvent(citySlug, date);
+  if (!city || !event) return {};
+  const fmtDate = formatDate(date);
+  return {
+    title: `AI Workshop — ${city.name} ${fmtDate} | Counterbench.AI`,
+    description: `Register for the ${fmtDate} AI workshop for legal professionals in ${city.name}, ${city.state}. From $597. Early bird $100 off.`,
+    alternates: { canonical: `https://counterbench.ai/workshops/${citySlug}/${date}` },
+    openGraph: {
+      title: `AI Workshop — ${city.name}, ${fmtDate}`,
+      description: `Hands-on AI training for legal professionals in ${city.name}. From $597.`,
+      type: "website",
+      url: `https://counterbench.ai/workshops/${citySlug}/${date}`
+    }
+  };
+}
+
+export default async function EventPage({ params }: { params: Promise<Params> }) {
+  const { city: citySlug, date } = await params;
+  const city = getCityInfo(citySlug);
+  const event = getEvent(citySlug, date);
+  if (!city || !event) notFound();
+
+  const earlyBird = hasEarlyBird(event);
+  const fmtDate = formatDate(date);
+  const spotsLeft = event.spotsTotal - event.spotsSold;
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "EducationEvent",
+    name: `AI for Legal Professionals — ${city.name}`,
+    description: "Full-day, hands-on AI workshop for paralegals, associates, and firm managers.",
+    startDate: event.date,
+    endDate: event.date,
+    eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
+    eventStatus: "https://schema.org/EventScheduled",
+    location: {
+      "@type": "Place",
+      name: event.venue,
+      address: {
+        "@type": "PostalAddress",
+        addressLocality: city.name,
+        addressRegion: city.state,
+        addressCountry: "US"
+      }
+    },
+    organizer: {
+      "@type": "Organization",
+      name: "CounterbenchAI",
+      url: "https://counterbench.ai"
+    },
+    offers: TIERS.map((t) => ({
+      "@type": "Offer",
+      name: t.name,
+      price: earlyBird ? t.earlyBirdPrice : t.price,
+      priceCurrency: "USD",
+      availability: spotsLeft > 0 ? "https://schema.org/InStock" : "https://schema.org/SoldOut",
+      validFrom: "2026-03-24"
+    }))
+  };
+
+  return (
+    <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 140, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label anim-hero anim-hero--1">
+            <Link href="/workshops" style={{ color: "inherit", textDecoration: "none" }}>
+              Workshops
+            </Link>{" "}
+            /{" "}
+            <Link href={`/workshops/${citySlug}`} style={{ color: "inherit", textDecoration: "none" }}>
+              {city.name}
+            </Link>{" "}
+            / {fmtDate}
+          </div>
+          <h1 className="max-w-900 anim-hero anim-hero--2">
+            AI for Legal Professionals
+            <br />
+            <em>{fmtDate}</em>
+          </h1>
+          <p className="max-w-600 mt-3 anim-hero anim-hero--3" style={{ fontSize: "1.0625rem", color: "var(--muted)" }}>
+            {event.venue} · {event.venueAddress}
+          </p>
+
+          <div className="flex flex--gap-3 mt-4 anim-hero anim-hero--4" style={{ flexWrap: "wrap", gap: "1rem" }}>
+            {earlyBird && (
+              <div style={{ background: "rgba(245, 158, 11, 0.12)", padding: "0.5rem 1rem", borderRadius: 8, fontSize: "0.875rem", color: "var(--amber)", fontWeight: 600 }}>
+                Early bird: $100 off — {event.earlyBirdSpotsTotal - event.earlyBirdSpotsSold} of {event.earlyBirdSpotsTotal} spots left
+              </div>
+            )}
+            <div style={{ background: "rgba(34, 197, 94, 0.1)", padding: "0.5rem 1rem", borderRadius: 8, fontSize: "0.875rem", color: "var(--green)" }}>
+              {spotsLeft} spots remaining
+            </div>
+          </div>
+
+          <div className="mt-5 anim-hero anim-hero--5">
+            <a className="btn btn--primary btn--arrow" href="#register">
+              Register Now
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Schedule */}
+      <section className="section section--alt section--border-t section--border-b">
+        <div className="container">
+          <div className="label">Schedule</div>
+          <h2 className="max-w-700">Full-day agenda</h2>
+
+          <div className="mt-6" style={{ display: "flex", flexDirection: "column", gap: "1rem", maxWidth: 700 }}>
+            {[
+              { time: "8:30 AM", label: "Check-in & coffee" },
+              { time: "9:00 AM", label: "Module 1: AI Fundamentals", duration: "90 min" },
+              { time: "10:30 AM", label: "Break" },
+              { time: "10:45 AM", label: "Module 2: Prompting That Works", duration: "90 min" },
+              { time: "12:15 PM", label: "Lunch (provided)" },
+              { time: "1:15 PM", label: "Module 3: AI for Your Workflow", duration: "90 min" },
+              { time: "2:45 PM", label: "Break" },
+              { time: "3:00 PM", label: "Module 4: Agents and Automation", duration: "60 min" },
+              { time: "4:00 PM", label: "Module 5: Your AI Action Plan", duration: "30 min" },
+              { time: "4:30 PM", label: "Wrap-up & networking" }
+            ].map((item) => (
+              <div
+                key={item.time}
+                style={{
+                  display: "flex",
+                  gap: "1.5rem",
+                  alignItems: "baseline",
+                  padding: "0.75rem 0",
+                  borderBottom: "1px solid var(--border)"
+                }}
+              >
+                <div style={{ width: 90, fontSize: "0.8125rem", color: "var(--muted)", fontWeight: 600, flexShrink: 0 }}>
+                  {item.time}
+                </div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontWeight: 500 }}>{item.label}</div>
+                  {item.duration && (
+                    <div style={{ fontSize: "0.8125rem", color: "var(--muted-2)", marginTop: "0.125rem" }}>
+                      {item.duration}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Register / Pricing */}
+      <section className="section section--border-b" id="register">
+        <div className="container">
+          <div className="label">Register</div>
+          <h2 className="max-w-700">
+            {city.name} — {fmtDate}
+          </h2>
+          {earlyBird && (
+            <p className="mt-3" style={{ color: "var(--amber)", fontWeight: 600 }}>
+              Early bird pricing active — $100 off all tiers.
+            </p>
+          )}
+
+          <div className="pricing-grid mt-6">
+            {TIERS.map((tier) => {
+              const price = earlyBird ? tier.earlyBirdPrice : tier.price;
+              return (
+                <div key={tier.name} className={`pricing-col${tier.featured ? " pricing-col--featured" : ""}`}>
+                  <div className="pricing-name">{tier.name}</div>
+                  <div className="pricing-price">
+                    ${price.toLocaleString()}
+                    {earlyBird && (
+                      <span style={{ fontSize: "0.875rem", color: "var(--muted-2)", textDecoration: "line-through", marginLeft: "0.5rem" }}>
+                        ${tier.price.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                  <p className="pricing-desc">{tier.includes.join(". ")}.</p>
+                  <WorkshopCheckout
+                    tierName={tier.name}
+                    price={price}
+                    eventCity={city.name}
+                    eventDate={event.date}
+                    featured={tier.featured}
+                  />
+                  <div className="pricing-divider" />
+                  {tier.includes.map((item) => (
+                    <div key={item} className={`pricing-feature-item${tier.featured ? " pricing-feature-item--highlight" : ""}`}>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+
+          <p className="mt-4 text-muted" style={{ fontSize: "0.8125rem" }}>
+            Full refund up to 7 days before the event. Transfer to a different date anytime. Firm-pays and self-pays: same price.
+          </p>
+        </div>
+      </section>
+
+      {/* Venue info */}
+      <section className="section section--alt section--border-b">
+        <div className="container">
+          <div className="grid grid--2 grid--gap-3">
+            <div>
+              <div className="label">Venue</div>
+              <h2 className="max-w-600">{event.venue}</h2>
+              <p className="mt-4" style={{ color: "var(--muted)" }}>{event.venueAddress}</p>
+              <p className="mt-3">
+                Exact venue details and directions will be emailed to registered attendees 1 week before the event.
+              </p>
+            </div>
+            <div>
+              <div className="card card--no-hover" style={{ height: "100%" }}>
+                <div className="label">What to bring</div>
+                <ul className="list mt-4">
+                  <li>Laptop with internet access</li>
+                  <li>A real work task (anonymized) for exercises</li>
+                  <li>Questions — lots of them</li>
+                </ul>
+                <div className="label mt-5">What we provide</div>
+                <ul className="list mt-4">
+                  <li>Printed quick-reference card</li>
+                  <li>Coffee, lunch, and afternoon snacks</li>
+                  <li>WiFi access</li>
+                  <li>All digital materials post-workshop</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA bottom */}
+      <section className="section section--border-b">
+        <div className="container" style={{ textAlign: "center" }}>
+          <div className="label">Ready?</div>
+          <h2 className="max-w-700" style={{ marginLeft: "auto", marginRight: "auto" }}>
+            AI won&apos;t replace paralegals.
+            <br />
+            <em>Paralegals who use AI will replace those who don&apos;t.</em>
+          </h2>
+          <div className="mt-5">
+            <a className="btn btn--primary btn--arrow" href="#register">
+              Register Now
+            </a>
+          </div>
+          <p className="mt-3 text-muted" style={{ fontSize: "0.8125rem" }}>
+            {fmtDate} · {city.name}, {city.state} · From ${earlyBird ? (TIERS[0]?.earlyBirdPrice ?? 497) : (TIERS[0]?.price ?? 597)}
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(marketing)/workshops/[city]/page.tsx
+++ b/app/(marketing)/workshops/[city]/page.tsx
@@ -1,0 +1,230 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { CITIES, getCityInfo, getEventsForCity, formatDate, hasEarlyBird, TIERS } from "@/data/workshops";
+import { StickyCta } from "@/components/StickyCta";
+
+export function generateStaticParams() {
+  return CITIES.map((c) => ({ city: c.slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ city: string }> }) {
+  const { city: citySlug } = await params;
+  const city = getCityInfo(citySlug);
+  if (!city) return {};
+  return {
+    title: `AI Workshops in ${city.name}, ${city.state} | Counterbench.AI`,
+    description: `In-person AI training for legal professionals in ${city.name}. One full day, hands-on, built for paralegals and attorneys. From $597.`,
+    alternates: { canonical: `https://counterbench.ai/workshops/${city.slug}` },
+    openGraph: {
+      title: `AI Workshops in ${city.name} — Counterbench.AI`,
+      description: `Hands-on AI workshop for legal professionals in ${city.name}, ${city.state}. From $597.`,
+      type: "website",
+      url: `https://counterbench.ai/workshops/${city.slug}`
+    }
+  };
+}
+
+export default async function CityWorkshopsPage({ params }: { params: Promise<{ city: string }> }) {
+  const { city: citySlug } = await params;
+  const city = getCityInfo(citySlug);
+  if (!city) notFound();
+
+  const events = getEventsForCity(citySlug);
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `CounterbenchAI Workshops — ${city.name}`,
+    itemListElement: events.map((e, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "EducationEvent",
+        name: `AI for Legal Professionals — ${city.name}`,
+        startDate: e.date,
+        location: {
+          "@type": "Place",
+          name: e.venue,
+          address: e.venueAddress
+        },
+        offers: TIERS.map((t) => ({
+          "@type": "Offer",
+          name: t.name,
+          price: t.price,
+          priceCurrency: "USD"
+        }))
+      }
+    }))
+  };
+
+  return (
+    <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 140, paddingBottom: "5rem" }}>
+        <div className="container">
+          <div className="label anim-hero anim-hero--1">
+            <Link href="/workshops" style={{ color: "inherit", textDecoration: "none" }}>
+              Workshops
+            </Link>{" "}
+            / {city.name}
+          </div>
+          <h1 className="max-w-900 anim-hero anim-hero--2">
+            AI Workshops in{" "}
+            <em>
+              {city.name}, {city.state}
+            </em>
+          </h1>
+          <p className="max-w-600 mt-4 anim-hero anim-hero--3" style={{ fontSize: "1.125rem" }}>
+            {city.description}
+          </p>
+          <div className="flex flex--gap-3 mt-5 flex--resp-col anim-hero anim-hero--4">
+            <a className="btn btn--primary btn--arrow" href="#events">
+              See Upcoming Dates
+            </a>
+            <Link className="btn btn--secondary" href="/workshops#curriculum">
+              View Curriculum
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Events list */}
+      <section className="section section--alt section--border-t section--border-b" id="events">
+        <div className="container">
+          <div className="label">Upcoming dates</div>
+          <h2 className="max-w-700">
+            {city.name} workshops
+          </h2>
+
+          {events.length === 0 ? (
+            <div className="card mt-6" style={{ maxWidth: 600 }}>
+              <p>No upcoming workshops in {city.name} yet. Check back soon or join the newsletter for updates.</p>
+              <div className="mt-4">
+                <Link className="btn btn--secondary btn--arrow" href="/newsletter">
+                  Get notified
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-6" style={{ display: "flex", flexDirection: "column", gap: "1.5rem" }}>
+              {events.map((event) => {
+                const earlyBird = hasEarlyBird(event);
+                const spotsLeft = event.spotsTotal - event.spotsSold;
+                return (
+                  <div key={event.date} className="card" style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: "1rem" }}>
+                      <div>
+                        <h3 style={{ fontSize: "1.25rem" }}>{formatDate(event.date)}</h3>
+                        <p style={{ fontSize: "0.875rem", color: "var(--muted)", marginTop: "0.25rem" }}>
+                          {event.venue} · {event.venueAddress}
+                        </p>
+                      </div>
+                      <div style={{ textAlign: "right" }}>
+                        {earlyBird && (
+                          <div style={{ fontSize: "0.8125rem", color: "var(--amber)", fontWeight: 600, marginBottom: "0.25rem" }}>
+                            Early bird: $100 off ({event.earlyBirdSpotsTotal - event.earlyBirdSpotsSold} spots left)
+                          </div>
+                        )}
+                        <div style={{ fontSize: "0.8125rem", color: "var(--muted)" }}>
+                          {spotsLeft} of {event.spotsTotal} spots remaining
+                        </div>
+                      </div>
+                    </div>
+
+                    <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", alignItems: "center" }}>
+                      <div style={{ fontSize: "0.875rem" }}>
+                        From <strong style={{ color: "var(--fg)" }}>{earlyBird ? "$497" : "$597"}</strong>
+                      </div>
+                      <Link
+                        className="btn btn--primary btn--arrow btn--sm"
+                        href={`/workshops/${citySlug}/${event.date}`}
+                      >
+                        Register
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Quick pricing */}
+      <section className="section section--border-b" id="pricing">
+        <div className="container">
+          <div className="label">Pricing</div>
+          <h2 className="max-w-700">Three tiers. Pick what fits.</h2>
+
+          <div className="pricing-grid mt-6">
+            {TIERS.map((tier) => (
+              <div key={tier.name} className={`pricing-col${tier.featured ? " pricing-col--featured" : ""}`}>
+                <div className="pricing-name">{tier.name}</div>
+                <div className="pricing-price">${tier.price.toLocaleString()}</div>
+                <p className="pricing-desc">
+                  {tier.includes[0]}.
+                </p>
+                {events[0] ? (
+                  <Link
+                    className={`btn ${tier.featured ? "btn--primary btn--arrow" : "btn--secondary"} btn--full`}
+                    href={`/workshops/${citySlug}/${events[0].date}`}
+                  >
+                    Register
+                  </Link>
+                ) : (
+                  <span className="btn btn--secondary btn--full" style={{ opacity: 0.5, pointerEvents: "none" }}>
+                    Coming soon
+                  </span>
+                )}
+                <div className="pricing-divider" />
+                {tier.includes.map((item) => (
+                  <div key={item} className={`pricing-feature-item${tier.featured ? " pricing-feature-item--highlight" : ""}`}>
+                    {item}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <p className="mt-4 text-muted" style={{ fontSize: "0.8125rem" }}>
+            Early bird ($100 off) applies to first 10 registrations per event, all tiers.
+          </p>
+        </div>
+      </section>
+
+      {/* Other city */}
+      <section className="section section--alt section--border-b">
+        <div className="container" style={{ textAlign: "center" }}>
+          <div className="label">Also available</div>
+          {CITIES.filter((c) => c.slug !== citySlug).map((other) => (
+            <div key={other.slug}>
+              <h2>
+                Workshops in {other.name}, {other.state}
+              </h2>
+              <p className="max-w-600 mt-3" style={{ marginLeft: "auto", marginRight: "auto" }}>
+                Same curriculum, different city. {other.tagline}.
+              </p>
+              <div className="mt-5">
+                <Link className="btn btn--secondary btn--arrow" href={`/workshops/${other.slug}`}>
+                  View {other.name} dates
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <StickyCta
+        text={
+          <>
+            <strong>Workshops in {city.name}.</strong> From ${events[0] && hasEarlyBird(events[0]) ? "497" : "597"}.
+          </>
+        }
+        ctaLabel="Register"
+        ctaHref="#events"
+      />
+    </main>
+  );
+}

--- a/app/(marketing)/workshops/page.tsx
+++ b/app/(marketing)/workshops/page.tsx
@@ -1,0 +1,484 @@
+import Link from "next/link";
+import { CITIES, EVENTS, formatDateShort, hasEarlyBird } from "@/data/workshops";
+import { StickyCta } from "@/components/StickyCta";
+
+export const metadata = {
+  title: "AI Workshops for Legal Professionals | Counterbench.AI",
+  description:
+    "In-person AI training for paralegals, associates, and firm managers. One full day. Hands-on exercises. Real legal workflows. Boston and Buffalo.",
+  alternates: { canonical: "https://counterbench.ai/workshops" },
+  openGraph: {
+    title: "AI Is Coming For Legal — Learn It Before It Learns You",
+    description:
+      "In-person AI workshops for legal professionals. One full day. Hands-on exercises. Boston and Buffalo.",
+    type: "website",
+    url: "https://counterbench.ai/workshops"
+  }
+};
+
+export default function WorkshopsPage() {
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "CounterbenchAI Legal AI Workshops",
+    description: "In-person AI training workshops for legal professionals",
+    itemListElement: EVENTS.map((e, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "EducationEvent",
+        name: `AI for Legal Professionals — ${e.city}`,
+        startDate: e.date,
+        location: {
+          "@type": "Place",
+          name: e.venue,
+          address: e.venueAddress
+        },
+        organizer: {
+          "@type": "Organization",
+          name: "CounterbenchAI"
+        }
+      }
+    }))
+  };
+
+  return (
+    <main className="page-workshops">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 140, paddingBottom: "5rem" }}>
+        <div className="container">
+          <div className="label anim-hero anim-hero--1">Live Workshops</div>
+          <h1 className="max-w-900 anim-hero anim-hero--2">
+            AI Is Coming For Legal —
+            <br />
+            <em>Learn It Before It Learns You.</em>
+          </h1>
+          <p className="max-w-600 mt-4 anim-hero anim-hero--3" style={{ fontSize: "1.125rem" }}>
+            Your boss wants you using AI. Here&apos;s how to actually do it. One full day, hands-on,
+            built for legal professionals who prefer learning from a person — not a YouTube tutorial.
+          </p>
+          <div className="flex flex--gap-3 mt-5 flex--resp-col anim-hero anim-hero--4">
+            <a className="btn btn--primary btn--arrow" href="#cities">
+              Choose Your City
+            </a>
+            <a className="btn btn--secondary" href="#curriculum">
+              See the Curriculum
+            </a>
+          </div>
+
+          <div
+            className="grid grid--3 grid--gap-2 mt-6 anim-hero anim-hero--5"
+            style={{ borderTop: "1px solid var(--border)", paddingTop: "2.5rem" }}
+          >
+            <div>
+              <div className="text-white" style={{ fontSize: "0.9375rem", fontWeight: 600 }}>
+                Hands-on, not lecture
+              </div>
+              <p style={{ fontSize: "0.875rem", marginTop: "0.5rem" }}>
+                Bring your real work. We&apos;ll prompt-engineer it live.
+              </p>
+            </div>
+            <div>
+              <div className="text-white" style={{ fontSize: "0.9375rem", fontWeight: 600 }}>
+                Legal-specific
+              </div>
+              <p style={{ fontSize: "0.875rem", marginTop: "0.5rem" }}>
+                Not generic AI. Discovery, drafting, research, case timelines.
+              </p>
+            </div>
+            <div>
+              <div className="text-white" style={{ fontSize: "0.9375rem", fontWeight: 600 }}>
+                Small class size
+              </div>
+              <p style={{ fontSize: "0.875rem", marginTop: "0.5rem" }}>
+                15–25 attendees. Enough room to ask questions without raising your hand.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Who it's for */}
+      <section className="section section--alt section--border-t section--border-b">
+        <div className="container">
+          <div className="grid grid--2 grid--gap-3">
+            <div>
+              <div className="label">Who this is for</div>
+              <h2 className="max-w-600">
+                Built for legal professionals
+                <br />
+                <em>who didn&apos;t ask for this.</em>
+              </h2>
+              <p className="mt-4 max-w-600">
+                Your firm just told you to &quot;figure out AI.&quot; No training, no budget for a consultant,
+                no idea where to start. You&apos;re not alone — and a full day with us will change that.
+              </p>
+            </div>
+            <div>
+              <div className="card card--no-hover" style={{ height: "100%" }}>
+                <div className="label">You&apos;ll get the most from this if you&apos;re a</div>
+                <ul className="list mt-4">
+                  <li>Paralegal or legal assistant at a small-to-mid firm</li>
+                  <li>Associate asked to evaluate or implement AI tools</li>
+                  <li>Office manager responsible for firm technology</li>
+                  <li>Managing partner who wants to understand before buying</li>
+                  <li>Legal professional who prefers in-person, hands-on learning</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Curriculum */}
+      <section className="section section--border-b" id="curriculum">
+        <div className="container">
+          <div className="label">Curriculum</div>
+          <h2 className="max-w-700">AI for Legal Professionals — From Zero to Productive.</h2>
+          <p className="max-w-600 mt-3">
+            8 hours. 5 modules. You leave with templates, a digital workbook, and an action plan
+            you&apos;ll actually use on Monday.
+          </p>
+
+          <div className="grid grid--2 grid--gap-2 mt-6">
+            <div className="card">
+              <div className="label">Module 1 · 90 min</div>
+              <h3>AI Fundamentals</h3>
+              <p className="mt-3">
+                What AI actually is (and isn&apos;t). ChatGPT vs Claude vs Copilot — when to use what. Live demo comparing
+                all three on the same legal task. Privacy and confidentiality: what&apos;s safe to put in.
+              </p>
+            </div>
+            <div className="card">
+              <div className="label">Module 2 · 90 min</div>
+              <h3>Prompting That Works</h3>
+              <p className="mt-3">
+                Why &quot;write me a brief&quot; fails. The CRAFT framework for non-technical users. Hands-on: bring your
+                real tasks, we prompt-engineer them live. Templates for summarization, research, and drafting.
+              </p>
+            </div>
+            <div className="card">
+              <div className="label">Module 3 · 90 min</div>
+              <h3>AI for Your Workflow</h3>
+              <p className="mt-3">
+                Document review and summarization. Legal research acceleration. Drafting and editing assistance.
+                Case timeline construction. Exercises with real (anonymized) legal documents.
+              </p>
+            </div>
+            <div className="card">
+              <div className="label">Module 4 · 60 min</div>
+              <h3>Agents and Automation</h3>
+              <p className="mt-3">
+                What AI agents are — practical, not theoretical. Build a simple workflow that saves 2 hours/week.
+                What&apos;s coming in 6–12 months and how to stay ahead.
+              </p>
+            </div>
+          </div>
+
+          <div className="card mt-4" style={{ maxWidth: 540 }}>
+            <div className="label">Module 5 · 30 min</div>
+            <h3>Your AI Action Plan</h3>
+            <p className="mt-3">
+              Identify 3 tasks you&apos;ll automate this week. Buddy system for accountability.
+              Access to private community for post-workshop support.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* What you get */}
+      <section className="section section--alt section--border-b">
+        <div className="container">
+          <div className="label">Materials</div>
+          <h2 className="max-w-700">What you walk away with.</h2>
+          <div className="grid grid--3 grid--gap-2 mt-6">
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">01</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>Quick-Reference Card</h3>
+                <p style={{ fontSize: "0.875rem" }}>Printed prompt templates for common legal tasks. Keep it on your desk.</p>
+              </div>
+            </div>
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">02</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>Digital Workbook</h3>
+                <p style={{ fontSize: "0.875rem" }}>All exercises, frameworks, and examples from the workshop.</p>
+              </div>
+            </div>
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">03</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>CounterbenchAI Access</h3>
+                <p style={{ fontSize: "0.875rem" }}>30–90 day free trial depending on your tier.</p>
+              </div>
+            </div>
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">04</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>Demo Recordings</h3>
+                <p style={{ fontSize: "0.875rem" }}>Recordings of all live demos for reference.</p>
+              </div>
+            </div>
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">05</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>Community Access</h3>
+                <p style={{ fontSize: "0.875rem" }}>Private community for Q&A and accountability.</p>
+              </div>
+            </div>
+            <div className="process-step" style={{ paddingTop: "1.5rem" }}>
+              <div className="process-num">06</div>
+              <div className="process-body">
+                <h3 style={{ fontSize: "1rem" }}>AI Action Plan</h3>
+                <p style={{ fontSize: "0.875rem" }}>Your personalized 3-task automation plan.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* City selector */}
+      <section className="section section--border-b" id="cities">
+        <div className="container">
+          <div className="label">Locations</div>
+          <h2 className="max-w-700">Choose your city.</h2>
+          <p className="max-w-600 mt-3">
+            Same curriculum. Same instructor. Pick the location and date that works for you.
+          </p>
+
+          <div className="grid grid--2 grid--gap-2 mt-6">
+            {CITIES.map((city) => {
+              const cityEvents = EVENTS.filter((e) => e.citySlug === city.slug);
+              const nextEvent = cityEvents[0];
+              return (
+                <Link
+                  key={city.slug}
+                  href={`/workshops/${city.slug}`}
+                  className="card"
+                  style={{ textDecoration: "none" }}
+                >
+                  <div className="label">
+                    {city.name}, {city.state}
+                  </div>
+                  <h3 style={{ fontSize: "1.25rem", marginTop: "0.5rem" }}>{city.tagline}</h3>
+                  <p className="mt-3" style={{ fontSize: "0.9375rem" }}>
+                    {city.description}
+                  </p>
+                  {nextEvent && (
+                    <div className="mt-4" style={{ fontSize: "0.875rem" }}>
+                      <span style={{ color: "var(--green)", fontWeight: 600 }}>
+                        Next: {formatDateShort(nextEvent.date)}
+                      </span>
+                      {hasEarlyBird(nextEvent) && (
+                        <span className="ml-2" style={{ color: "var(--amber)", marginLeft: "0.75rem" }}>
+                          Early bird available
+                        </span>
+                      )}
+                    </div>
+                  )}
+                  <div className="mt-4">
+                    <span className="btn btn--secondary btn--sm btn--arrow">View dates &amp; register</span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing overview */}
+      <section className="section section--alt section--border-b" id="pricing">
+        <div className="container">
+          <div className="label">Pricing</div>
+          <h2 className="max-w-700">Three tiers. No hidden fees.</h2>
+          <p className="max-w-600 mt-3">
+            Early bird: $100 off for the first 10 registrations per event.
+          </p>
+
+          <div className="pricing-grid mt-6">
+            <div className="pricing-col">
+              <div className="pricing-name">Standard</div>
+              <div className="pricing-price">
+                $597
+              </div>
+              <p className="pricing-desc">
+                Full workshop + materials + 30-day CounterbenchAI access.
+              </p>
+              <a className="btn btn--secondary btn--full" href="#cities">
+                Choose City
+              </a>
+              <div className="pricing-divider" />
+              <div className="pricing-feature-item">Full-day workshop (8 hours)</div>
+              <div className="pricing-feature-item">Printed quick-reference card</div>
+              <div className="pricing-feature-item">Digital workbook</div>
+              <div className="pricing-feature-item">30-day CounterbenchAI access</div>
+              <div className="pricing-feature-item">Demo recordings</div>
+              <div className="pricing-feature-item" style={{ color: "var(--muted-2)", textDecoration: "line-through", opacity: 0.5 }}>
+                1-on-1 follow-up call
+              </div>
+              <div className="pricing-feature-item" style={{ color: "var(--muted-2)", textDecoration: "line-through", opacity: 0.5 }}>
+                Firm-specific session
+              </div>
+            </div>
+
+            <div className="pricing-col pricing-col--featured">
+              <div className="pricing-name">Premium</div>
+              <div className="pricing-price">
+                $897
+              </div>
+              <p className="pricing-desc">
+                Standard + 1-on-1 follow-up call + 90-day CounterbenchAI access.
+              </p>
+              <a className="btn btn--primary btn--full btn--arrow" href="#cities">
+                Choose City
+              </a>
+              <div className="pricing-divider" />
+              <div className="pricing-feature-item pricing-feature-item--highlight">Everything in Standard</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">1-on-1 follow-up call (30 min)</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">90-day CounterbenchAI access</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">Priority seating</div>
+              <div className="pricing-feature-item" style={{ color: "var(--muted-2)", textDecoration: "line-through", opacity: 0.5 }}>
+                Firm-specific session
+              </div>
+            </div>
+
+            <div className="pricing-col">
+              <div className="pricing-name">Firm Package</div>
+              <div className="pricing-price">
+                $2,497
+              </div>
+              <p className="pricing-desc">
+                4 seats + private 1-hour firm-specific session + annual CounterbenchAI.
+              </p>
+              <a className="btn btn--secondary btn--full" href="#cities">
+                Choose City
+              </a>
+              <div className="pricing-divider" />
+              <div className="pricing-feature-item pricing-feature-item--highlight">4 seats (Standard tier)</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">Private 1-hour firm session</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">Annual CounterbenchAI access</div>
+              <div className="pricing-feature-item pricing-feature-item--highlight">Dedicated point of contact</div>
+            </div>
+          </div>
+
+          <p className="mt-4 text-muted" style={{ fontSize: "0.8125rem" }}>
+            Early bird pricing ($100 off) applies to the first 10 registrations per event, all tiers. Firm-pays and self-pays: same price.
+          </p>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="section section--border-b">
+        <div className="container">
+          <div className="label">FAQ</div>
+          <h2 className="max-w-600">Common questions.</h2>
+
+          <div className="faq-grid mt-6">
+            <details className="faq-item" open>
+              <summary className="faq-q">Do I need to know anything about AI?</summary>
+              <div className="faq-a">
+                <p>
+                  No. We start from zero. If you can use email and a web browser, you have enough technical
+                  skill for this workshop.
+                </p>
+              </div>
+            </details>
+            <details className="faq-item" open>
+              <summary className="faq-q">Will my firm reimburse this?</summary>
+              <div className="faq-a">
+                <p>
+                  Most firms cover professional development. We provide a receipt and certificate of attendance.
+                  Many attendees expense it as CLE or training.
+                </p>
+              </div>
+            </details>
+            <details className="faq-item" open>
+              <summary className="faq-q">Is this CLE accredited?</summary>
+              <div className="faq-a">
+                <p>
+                  We&apos;re applying for CLE accreditation with the MA Board of Bar Overseers and the NY CLE Board.
+                  We&apos;ll update this page when approved. The first workshops run without CLE credit.
+                </p>
+              </div>
+            </details>
+            <details className="faq-item">
+              <summary className="faq-q">What should I bring?</summary>
+              <div className="faq-a">
+                <p>
+                  A laptop with internet access. We provide everything else. Bring a real work task
+                  (anonymized) — we&apos;ll use it in the exercises.
+                </p>
+              </div>
+            </details>
+            <details className="faq-item">
+              <summary className="faq-q">What if I can&apos;t make it after registering?</summary>
+              <div className="faq-a">
+                <p>
+                  Full refund up to 7 days before the event. Transfer to a different date anytime.
+                  Send a colleague in your place if needed.
+                </p>
+              </div>
+            </details>
+            <details className="faq-item">
+              <summary className="faq-q">How is this different from an online course?</summary>
+              <div className="faq-a">
+                <p>
+                  Online courses are passive. This is active: you work on your actual tasks, get feedback
+                  in real time, and leave with muscle memory, not just bookmarks.
+                </p>
+              </div>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      {/* Cross-sell to Advisory */}
+      <section className="section section--alt section--border-b">
+        <div className="container">
+          <div className="grid grid--2 grid--gap-3">
+            <div>
+              <div className="label">For firm leadership</div>
+              <h2 className="max-w-600">
+                Need more than a workshop?
+              </h2>
+              <p className="max-w-600 mt-4">
+                If your firm needs a systematic AI strategy — not just training — our Advisory practice
+                designs implementation roadmaps, vendor evaluations, and adoption frameworks for plaintiff firms.
+              </p>
+              <div className="mt-5">
+                <Link className="btn btn--secondary btn--arrow" href="/advisory?from=workshops">
+                  Learn about Advisory
+                </Link>
+              </div>
+            </div>
+            <div className="card card--no-hover" style={{ display: "flex", flexDirection: "column", justifyContent: "center" }}>
+              <div className="label">Also available</div>
+              <h3 style={{ fontSize: "1.25rem", marginBottom: "0.75rem" }}>Free AI Diagnostic</h3>
+              <p style={{ fontSize: "0.9375rem" }}>
+                Not sure where to start? The Case Diagnostic gives your firm a matter-specific leverage map in 48 hours.
+              </p>
+              <div className="mt-4">
+                <Link className="btn btn--secondary btn--arrow" href="/diagnostic?from=workshops">
+                  See the Diagnostic
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <StickyCta
+        text={
+          <>
+            <strong>$100 off early bird.</strong> First 10 seats per event.
+          </>
+        }
+        ctaLabel="Register Now"
+        ctaHref="#cities"
+      />
+    </main>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -146,6 +146,10 @@ export function SiteHeader() {
             )}
           </div>
 
+          <Link className={`btn btn--secondary btn--sm ${isActive(pathname, "/workshops") ? "is-active" : ""}`} href="/workshops">
+            Workshops
+          </Link>
+
           <Link className={`btn btn--secondary btn--sm ${isActive(pathname, "/advisory") ? "is-active" : ""}`} href="/advisory">
             AI Advisory
           </Link>

--- a/components/WorkshopCheckout.tsx
+++ b/components/WorkshopCheckout.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+declare global {
+  interface Window {
+    dataLayer?: Record<string, unknown>[];
+  }
+}
+
+export function WorkshopCheckout({
+  tierName,
+  price,
+  eventCity,
+  eventDate,
+  featured
+}: {
+  tierName: string;
+  price: number;
+  eventCity: string;
+  eventDate: string;
+  featured?: boolean;
+}) {
+  const handleClick = () => {
+    // Push GTM event for tracking
+    if (typeof window !== "undefined" && window.dataLayer) {
+      window.dataLayer.push({
+        event: "workshop_registration",
+        workshop_tier: tierName,
+        workshop_price: price,
+        workshop_city: eventCity,
+        workshop_date: eventDate
+      });
+    }
+
+    // Stripe checkout URL — configured via env vars.
+    // When Stripe is set up, replace this with actual checkout links or Stripe.js integration.
+    const stripeUrl = process.env.NEXT_PUBLIC_STRIPE_WORKSHOP_CHECKOUT_URL;
+    if (stripeUrl) {
+      const url = new URL(stripeUrl);
+      url.searchParams.set("tier", tierName.toLowerCase().replace(/\s+/g, "-"));
+      url.searchParams.set("city", eventCity.toLowerCase());
+      url.searchParams.set("date", eventDate);
+      window.location.href = url.toString();
+    } else {
+      // Fallback: scroll to a contact/waitlist section or alert
+      alert(
+        `Registration for ${tierName} ($${price}) — ${eventCity}, ${eventDate}.\n\nStripe checkout is not yet configured. Contact us to register.`
+      );
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`btn ${featured ? "btn--primary btn--arrow" : "btn--secondary"} btn--full`}
+      onClick={handleClick}
+      data-track={`Register ${tierName}`}
+      data-location="workshop-pricing"
+    >
+      Register — ${price.toLocaleString()}
+    </button>
+  );
+}

--- a/data/workshops.ts
+++ b/data/workshops.ts
@@ -1,0 +1,154 @@
+export type WorkshopTier = {
+  name: string;
+  price: number;
+  earlyBirdPrice: number;
+  stripePriceId: string;
+  earlyBirdStripePriceId: string;
+  includes: string[];
+  featured?: boolean;
+};
+
+export type WorkshopEvent = {
+  city: string;
+  citySlug: string;
+  date: string; // YYYY-MM-DD
+  dayOfWeek: string;
+  venue: string;
+  venueAddress: string;
+  spotsTotal: number;
+  spotsSold: number;
+  earlyBirdSpotsTotal: number;
+  earlyBirdSpotsSold: number;
+};
+
+export type CityInfo = {
+  name: string;
+  slug: string;
+  state: string;
+  tagline: string;
+  description: string;
+};
+
+export const CITIES: CityInfo[] = [
+  {
+    name: "Boston",
+    slug: "boston",
+    state: "MA",
+    tagline: "Fridays in Boston",
+    description:
+      "Join legal professionals across the Greater Boston area for a hands-on, full-day AI workshop. Held on Fridays so your firm can invest in your professional development."
+  },
+  {
+    name: "Buffalo",
+    slug: "buffalo",
+    state: "NY",
+    tagline: "Saturdays in Buffalo",
+    description:
+      "Western New York's only in-person AI workshop built for legal professionals. Small classes, real exercises, no fluff. Saturdays so you can learn on your own schedule."
+  }
+];
+
+export const TIERS: WorkshopTier[] = [
+  {
+    name: "Standard",
+    price: 597,
+    earlyBirdPrice: 497,
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_STANDARD_PRICE_ID || "",
+    earlyBirdStripePriceId: process.env.NEXT_PUBLIC_STRIPE_STANDARD_EB_PRICE_ID || "",
+    includes: [
+      "Full-day workshop (8 hours)",
+      "Printed quick-reference card",
+      "Digital workbook with all exercises",
+      "30-day free CounterbenchAI access",
+      "Recording of all demos"
+    ]
+  },
+  {
+    name: "Premium",
+    price: 897,
+    earlyBirdPrice: 797,
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_PREMIUM_PRICE_ID || "",
+    earlyBirdStripePriceId: process.env.NEXT_PUBLIC_STRIPE_PREMIUM_EB_PRICE_ID || "",
+    includes: [
+      "Everything in Standard",
+      "1-on-1 follow-up call (30 min)",
+      "90-day free CounterbenchAI access",
+      "Priority seating"
+    ],
+    featured: true
+  },
+  {
+    name: "Firm Package",
+    price: 2497,
+    earlyBirdPrice: 2397,
+    stripePriceId: process.env.NEXT_PUBLIC_STRIPE_FIRM_PRICE_ID || "",
+    earlyBirdStripePriceId: process.env.NEXT_PUBLIC_STRIPE_FIRM_EB_PRICE_ID || "",
+    includes: [
+      "4 seats (Standard tier)",
+      "Private 1-hour firm-specific session",
+      "Annual CounterbenchAI access for all attendees",
+      "Dedicated point of contact"
+    ]
+  }
+];
+
+export const EVENTS: WorkshopEvent[] = [
+  {
+    city: "Boston",
+    citySlug: "boston",
+    date: "2026-04-24",
+    dayOfWeek: "Friday",
+    venue: "TBD — Back Bay / Financial District",
+    venueAddress: "Boston, MA",
+    spotsTotal: 25,
+    spotsSold: 0,
+    earlyBirdSpotsTotal: 10,
+    earlyBirdSpotsSold: 0
+  },
+  {
+    city: "Buffalo",
+    citySlug: "buffalo",
+    date: "2026-05-02",
+    dayOfWeek: "Saturday",
+    venue: "TBD — Downtown Buffalo",
+    venueAddress: "Buffalo, NY",
+    spotsTotal: 20,
+    spotsSold: 0,
+    earlyBirdSpotsTotal: 10,
+    earlyBirdSpotsSold: 0
+  }
+];
+
+export function getEventsForCity(citySlug: string): WorkshopEvent[] {
+  return EVENTS.filter((e) => e.citySlug === citySlug);
+}
+
+export function getEvent(citySlug: string, date: string): WorkshopEvent | undefined {
+  return EVENTS.find((e) => e.citySlug === citySlug && e.date === date);
+}
+
+export function getCityInfo(citySlug: string): CityInfo | undefined {
+  return CITIES.find((c) => c.slug === citySlug);
+}
+
+export function hasEarlyBird(event: WorkshopEvent): boolean {
+  return event.earlyBirdSpotsSold < event.earlyBirdSpotsTotal;
+}
+
+export function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00");
+  return d.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric"
+  });
+}
+
+export function formatDateShort(dateStr: string): string {
+  const d = new Date(dateStr + "T12:00:00");
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric"
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
       "@/design-system/*": [
         "design-system/*"
       ],
+      "@/data/*": [
+        "data/*"
+      ],
       "@/lib/*": [
         "lib/*"
       ]


### PR DESCRIPTION
## Summary
- Adds full workshop funnel: `/workshops` (main landing with city selector), `/workshops/[city]` (Boston/Buffalo event listings), `/workshops/[city]/[date]` (individual event pages with 3-tier pricing and checkout)
- Three pricing tiers: Standard $597, Premium $897, Firm Package $2,497 with early bird $100 off for first 10 registrations
- Headline: "AI Is Coming For Legal — Learn It Before It Learns You"
- WorkshopCheckout component with GTM `workshop_registration` event tracking
- Schema.org structured data (EducationEvent) on all pages
- "Workshops" nav link added to SiteHeader
- Matches existing site design system (CSS classes, section patterns, pricing grid, FAQ, sticky CTA)

## Architecture
- `data/workshops.ts` — centralized workshop data (cities, events, tiers, pricing)
- `components/WorkshopCheckout.tsx` — client component for Stripe checkout integration (env-configurable)
- Event pages are statically generated via `generateStaticParams`
- Stripe checkout URL configured via `NEXT_PUBLIC_STRIPE_WORKSHOP_CHECKOUT_URL` env var (falls back to alert when not set)

## To activate Stripe
Set these env vars in Vercel:
- `NEXT_PUBLIC_STRIPE_WORKSHOP_CHECKOUT_URL` — Stripe Checkout session URL
- Optionally: individual price IDs per tier for future Stripe.js integration

## Test plan
- [x] `npm run build` passes
- [ ] Visual check of `/workshops`, `/workshops/boston`, `/workshops/buffalo`, `/workshops/boston/2026-04-24`
- [ ] Verify GTM dataLayer push on checkout click
- [ ] Verify Stripe checkout flow once env vars are configured
- [ ] Mobile responsive check

🤖 Generated with [Claude Code](https://claude.com/claude-code)