### PR TITLE
feat: add /paralegals page and migrate VerdictOps blog posts

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -74,6 +74,27 @@ export default function HomePage() {
       <HeroSection />
 
       <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container">
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: "2rem", flexWrap: "wrap" }}>
+            <div style={{ maxWidth: 600 }}>
+              <div className="label" style={{ display: "inline-block" }}>For PI firms</div>
+              <h2 className="mt-2" style={{ fontSize: "1.75rem", lineHeight: 1.2 }}>
+                Need a team to run the tools?
+              </h2>
+              <p className="mt-3" style={{ fontSize: "1.0625rem", color: "var(--text-muted)" }}>
+                Dedicated paralegal pods handle your intake, records, med chronologies, and client communication — with AI already built into how they work. Live in 2-3 weeks. No hiring. No turnover.
+              </p>
+            </div>
+            <div style={{ flexShrink: 0 }}>
+              <Link className="btn btn--primary btn--arrow" href="/paralegals">
+                See paralegal teams
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
         <div className="container" style={{ textAlign: "center" }}>
           <div className="label" style={{ display: "inline-block" }}>Stay current</div>
           <h2 className="max-w-700" style={{ marginLeft: "auto", marginRight: "auto" }}>

--- a/app/(marketing)/paralegals/page.tsx
+++ b/app/(marketing)/paralegals/page.tsx
@@ -1,0 +1,287 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Paralegal Teams for PI Firms | Counterbench.AI",
+  description:
+    "Dedicated paralegal pods for personal injury firms. Intake, records, med chronologies, and client communication — with AI built in. Live in 2-3 weeks. From $3,750/mo.",
+  alternates: { canonical: "https://counterbench.ai/paralegals" },
+  openGraph: {
+    title: "Paralegal Teams for PI Firms | Counterbench.AI",
+    description:
+      "Dedicated paralegal pods for PI firms. Intake, records, med chronologies — AI-enabled, no hiring, no turnover. From $3,750/mo.",
+    type: "website",
+    url: "https://counterbench.ai/paralegals"
+  }
+};
+
+const tiers = [
+  {
+    name: "Core",
+    bestFor: "Solo practitioners and 2-4 attorney firms handling 20-40 cases/month",
+    price: "$3,750",
+    capacity: "Up to 80-120 hours/month",
+    features: [
+      "Dedicated paralegal pod",
+      "Intake and client communication management",
+      "Record requests and tracking",
+      "Medical chronology preparation",
+      "Case status reporting and updates",
+      "Weekly quality assurance",
+    ],
+    replaces: "½–¾ of a full-time paralegal. Salary + benefits: $55K–65K. Recruiting timeline: 3–6 months.",
+    highlighted: false,
+  },
+  {
+    name: "Scale",
+    bestFor: "4-10 attorney firms with high-volume caseloads",
+    price: "$6,500",
+    priceNote: "Custom pricing starting at",
+    capacity: "120-160+ hours/month",
+    features: [
+      "Everything in Core",
+      "Litigation document drafting and support",
+      "Demand packet assembly and indexing",
+      "Priority request handling and expedited turnaround",
+      "Legal research and case analysis support",
+      "Dedicated account manager",
+      "Advanced reporting and analytics",
+      "Custom workflow integration",
+    ],
+    replaces: "1–2 full-time paralegals. Annual costs: $110K–170K (salary + benefits + recruiting).",
+    highlighted: true,
+  },
+];
+
+const addOns = [
+  { name: "Extra 20-hour block", price: "$850", description: "One-time add for additional capacity beyond your plan." },
+  { name: "Rush / same-day request", price: "$250", description: "Expedited turnaround on urgent intake, records, or drafting." },
+  { name: "Medical chronology (flat fee)", price: "$750", description: "Complete medical chronology assembly from records and imaging." },
+  { name: "Demand package assembly (flat fee)", price: "$500", description: "Complete demand packet, indexed and formatted." },
+  { name: "After-hours coverage", price: "$400/mo", description: "Evening and weekend support." },
+];
+
+const faqs = [
+  {
+    q: "What happens if I need more capacity mid-month?",
+    a: "Add extra 20-hour blocks ($850 each) anytime. If you're consistently exceeding capacity, we'll upgrade you to the next tier and prorate the difference — no penalties.",
+  },
+  {
+    q: "Can I cancel anytime?",
+    a: "Yes. Month-to-month only. No long-term contracts, no lock-ins. Cancel with 30 days' notice and we'll do a graceful transition.",
+  },
+  {
+    q: "Who are the paralegals on my pod? Can I meet them?",
+    a: "Your pod is managed by a core paralegal team overseen by a pod manager. We introduce them during onboarding and you'll have direct Slack/email access. Scale customers get a dedicated account manager.",
+  },
+  {
+    q: "What case management systems do you work with?",
+    a: "We integrate with most PI case management systems — Clio, CaseWare, Centerbase, MyCase, and others. We also work via email, Slack, Google Drive, and OneDrive. During discovery, we'll map your specific workflow.",
+  },
+  {
+    q: "Is my data secure?",
+    a: "Yes. SOC 2 Type II certified, US-hosted, encrypted at rest and in transit. All team members sign NDAs. Compliance is baseline, not an add-on.",
+  },
+  {
+    q: "How quickly can I go live?",
+    a: "Typically 2-3 weeks from signed agreement to first active pod. We handle onboarding, system access, and workflow mapping during that window.",
+  },
+];
+
+export default function ParalegalsPage() {
+  return (
+    <main>
+      {/* Hero */}
+      <section className="section" style={{ paddingTop: 120, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label" style={{ display: "inline-block" }}>For PI firms</div>
+          <h1 className="max-w-900 mt-2">
+            Stop drowning in intake and records requests. Start closing more cases.
+          </h1>
+          <p className="max-w-700 mt-3" style={{ fontSize: "1.1875rem", lineHeight: 1.6 }}>
+            Dedicated paralegal pods handle your intake, records, med chronologies, and client communication — with AI already built into how they work. No hiring. No training. No turnover.
+          </p>
+          <div className="mt-4" style={{ display: "flex", gap: "1rem", flexWrap: "wrap", alignItems: "center" }}>
+            <Link className="btn btn--primary btn--arrow" href="/contact">
+              Book a discovery call
+            </Link>
+            <a className="btn btn--secondary" href="#pricing">
+              See pricing
+            </a>
+          </div>
+          <div className="mt-4" style={{ borderTop: "1px solid var(--border)", paddingTop: "1.25rem" }}>
+            <div className="grid grid--4 grid--gap-2" style={{ maxWidth: 900 }}>
+              {[
+                "Trusted by firms handling 50+ active cases",
+                "US-hosted, SOC 2-certified",
+                "Live in 2-3 weeks",
+                "Cancel anytime",
+              ].map((point) => (
+                <div key={point} style={{ fontSize: "0.875rem", display: "flex", gap: "0.5rem", alignItems: "flex-start" }}>
+                  <span style={{ color: "var(--accent)", flexShrink: 0 }}>✓</span>
+                  <span>{point}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* What we handle */}
+      <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container">
+          <div className="label" style={{ display: "inline-block" }}>What we handle</div>
+          <h2 className="mt-2" style={{ maxWidth: 560 }}>The work that quietly breaks your week.</h2>
+          <div className="grid grid--3 grid--gap-2 mt-4">
+            {[
+              {
+                title: "Intake + client comms",
+                body: "Calls, follow-ups, pipeline hygiene, appointment scheduling. Nothing falls through.",
+              },
+              {
+                title: "Records + demands",
+                body: "Requesting, tracking, indexing, summaries, demand packet assembly, and consistent status reporting.",
+              },
+              {
+                title: "Drafting + overflow",
+                body: "Litigation support and drafting under your supervision — clean, structured, on template.",
+              },
+            ].map((s) => (
+              <div key={s.title} style={{ borderLeft: "2px solid var(--accent)", paddingLeft: "1.25rem" }}>
+                <div style={{ fontWeight: 600, fontSize: "1rem" }}>{s.title}</div>
+                <p className="mt-2" style={{ fontSize: "0.9375rem", color: "var(--text-muted)" }}>{s.body}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Stats */}
+      <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container">
+          <div className="grid grid--4 grid--gap-2">
+            {[
+              { label: "Avg response time", value: "4.2 hrs" },
+              { label: "Coverage", value: "24/5" },
+              { label: "Weekly QA accuracy", value: "98.2%" },
+              { label: "Active pods deployed", value: "40+" },
+            ].map((s) => (
+              <div key={s.label}>
+                <div style={{ fontSize: "2.5rem", fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1 }}>{s.value}</div>
+                <div className="mt-2" style={{ fontSize: "0.8125rem", color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em", fontWeight: 600 }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section className="section" id="pricing" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container">
+          <div className="label" style={{ display: "inline-block" }}>Pricing</div>
+          <h2 className="mt-2">Straightforward. Month-to-month. No lock-ins.</h2>
+          <div className="grid grid--2 grid--gap-2 mt-4">
+            {tiers.map((tier) => (
+              <div
+                key={tier.name}
+                style={{
+                  border: `1px solid ${tier.highlighted ? "var(--accent)" : "var(--border)"}`,
+                  borderRadius: 12,
+                  padding: "2rem",
+                  background: tier.highlighted ? "var(--card-bg, var(--bg-alt))" : "transparent",
+                }}
+              >
+                {tier.highlighted && (
+                  <div className="label" style={{ display: "inline-block", marginBottom: "1rem" }}>Most popular</div>
+                )}
+                <div style={{ fontWeight: 700, fontSize: "1.125rem" }}>{tier.name}</div>
+                <div style={{ marginTop: "0.5rem" }}>
+                  {tier.priceNote && <span style={{ fontSize: "0.8125rem", color: "var(--text-muted)" }}>{tier.priceNote} </span>}
+                  <span style={{ fontSize: "2rem", fontWeight: 800, letterSpacing: "-0.03em" }}>{tier.price}</span>
+                  <span style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>/mo</span>
+                </div>
+                <div className="mt-1" style={{ fontSize: "0.875rem", color: "var(--text-muted)" }}>{tier.capacity}</div>
+                <div className="mt-1" style={{ fontSize: "0.8125rem", color: "var(--text-muted)" }}>{tier.bestFor}</div>
+                <ul className="mt-3" style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                  {tier.features.map((f) => (
+                    <li key={f} style={{ display: "flex", gap: "0.5rem", fontSize: "0.9375rem", alignItems: "flex-start" }}>
+                      <span style={{ color: "var(--accent)", flexShrink: 0, marginTop: 2 }}>✓</span>
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+                <div className="mt-3" style={{ fontSize: "0.8125rem", color: "var(--text-muted)", borderTop: "1px solid var(--border)", paddingTop: "0.75rem" }}>
+                  Replaces: {tier.replaces}
+                </div>
+                <div className="mt-3">
+                  <Link className="btn btn--primary btn--arrow" href="/contact">
+                    Get started
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Add-ons */}
+          <div className="mt-4">
+            <div style={{ fontWeight: 600, fontSize: "0.9375rem", marginBottom: "1rem" }}>Add-ons</div>
+            <div className="grid grid--3 grid--gap-2">
+              {addOns.map((a) => (
+                <div key={a.name} style={{ borderTop: "1px solid var(--border)", paddingTop: "0.75rem" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: "0.5rem" }}>
+                    <span style={{ fontWeight: 600, fontSize: "0.9375rem" }}>{a.name}</span>
+                    <span style={{ fontWeight: 700, fontSize: "0.9375rem", flexShrink: 0 }}>{a.price}</span>
+                  </div>
+                  <p className="mt-1" style={{ fontSize: "0.8125rem", color: "var(--text-muted)" }}>{a.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container">
+          <div className="label" style={{ display: "inline-block" }}>FAQ</div>
+          <h2 className="mt-2" style={{ maxWidth: 480 }}>Common questions.</h2>
+          <div className="mt-4" style={{ display: "flex", flexDirection: "column", gap: "1.5rem", maxWidth: 720 }}>
+            {faqs.map((faq) => (
+              <div key={faq.q} style={{ borderTop: "1px solid var(--border)", paddingTop: "1.25rem" }}>
+                <div style={{ fontWeight: 600, fontSize: "1rem" }}>{faq.q}</div>
+                <p className="mt-2" style={{ fontSize: "0.9375rem", color: "var(--text-muted)", lineHeight: 1.65 }}>{faq.a}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="section" style={{ borderTop: "1px solid var(--border)" }}>
+        <div className="container" style={{ textAlign: "center" }}>
+          <div className="label" style={{ display: "inline-block" }}>Get started</div>
+          <h2 className="max-w-600 mt-2" style={{ marginLeft: "auto", marginRight: "auto" }}>
+            Ready to scale your firm?
+          </h2>
+          <p className="max-w-500 mt-3" style={{ marginLeft: "auto", marginRight: "auto", fontSize: "1.0625rem", color: "var(--text-muted)" }}>
+            Book a 30-minute discovery call. We map your workflow, propose the right pod structure, and give you pricing and a launch timeline.
+          </p>
+          <div className="mt-4" style={{ display: "flex", gap: "1rem", justifyContent: "center", flexWrap: "wrap" }}>
+            <Link className="btn btn--primary btn--arrow" href="/contact">
+              Book a discovery call
+            </Link>
+            <a className="btn btn--secondary" href="#pricing">
+              See pricing
+            </a>
+          </div>
+          <div className="mt-4" style={{ display: "flex", gap: "2rem", justifyContent: "center", flexWrap: "wrap", fontSize: "0.875rem", color: "var(--text-muted)" }}>
+            {["No long-term contracts", "Cancel anytime", "Live in 2-3 weeks"].map((p) => (
+              <span key={p} style={{ display: "flex", gap: "0.375rem", alignItems: "center" }}>
+                <span style={{ color: "var(--accent)" }}>✓</span> {p}
+              </span>
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/(marketing)/workshop/page.tsx
+++ b/app/(marketing)/workshop/page.tsx
@@ -260,6 +260,37 @@ export default function WorkshopPage() {
         </div>
       </section>
 
+      {/* Instructor bio */}
+      <section className="section section--border-b" id="instructor">
+        <div className="container">
+          <div className="label">Your Instructor</div>
+          <h2 className="max-w-700">Who&rsquo;s running this.</h2>
+
+          <div className="ws-instructor mt-6">
+            <div className="ws-instructor-avatar" aria-hidden="true">PR</div>
+            <div className="ws-instructor-body">
+              <div className="text-white" style={{ fontSize: "1.125rem", fontWeight: 700, marginBottom: "0.25rem" }}>
+                Philipp Rimmler
+              </div>
+              <div style={{ fontSize: "0.875rem", color: "var(--muted)", marginBottom: "1.25rem" }}>
+                Founder, CounterbenchAI
+              </div>
+              <p style={{ marginBottom: "0.875rem" }}>
+                Philipp has spent years helping legal teams cut through operational drag — first as a strategy
+                consultant, then as the builder behind CounterbenchAI. He designed the workshop curriculum
+                around the actual workflows paralegals and legal ops teams deal with every day, not vendor
+                demos or theoretical use cases.
+              </p>
+              <p style={{ marginBottom: 0 }}>
+                He teaches this workshop because the gap between &ldquo;AI is coming for legal&rdquo; and
+                &ldquo;here&rsquo;s exactly how to use it in your intake queue on Monday&rdquo; is where most
+                training fails. This workshop exists to close that gap.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* Who it's for */}
       <section className="section section--border-b">
         <div className="container">

--- a/app/(marketing)/workshops/page.tsx
+++ b/app/(marketing)/workshops/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+
+export function generateMetadata() {
+  return {
+    title: "AI for Legal Workshop — CounterbenchAI",
+    robots: { index: false },
+  };
+}
+
+export default function WorkshopsRedirect() {
+  redirect("/workshop");
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -862,3 +862,35 @@ html[data-theme="light"] .ws-earlybird {
   line-height: 1.7;
   color: var(--muted);
 }
+.ws-instructor {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 2rem;
+  align-items: start;
+  max-width: 720px;
+}
+@media (max-width: 600px) {
+  .ws-instructor {
+    grid-template-columns: 1fr;
+  }
+}
+.ws-instructor-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  background: rgba(170, 185, 209, 0.12);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--teal);
+  letter-spacing: -0.02em;
+}
+.ws-instructor-body p {
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--muted);
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -25,6 +25,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/resources/open-legal-data-map"), lastModified: now, changeFrequency: "weekly", priority: 0.7 },
     { url: absoluteUrl("/resources/contract-qa-pipeline-map"), lastModified: now, changeFrequency: "weekly", priority: 0.69 },
     { url: absoluteUrl("/resources/attribution"), lastModified: now, changeFrequency: "monthly", priority: 0.2 },
+    { url: absoluteUrl("/paralegals"), lastModified: now, changeFrequency: "monthly", priority: 0.8 },
     { url: absoluteUrl("/advisory"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/diagnostic"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/newsletter"), lastModified: now, changeFrequency: "weekly", priority: 0.7 },

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -146,6 +146,10 @@ export function SiteHeader() {
             )}
           </div>
 
+          <Link className={`btn btn--secondary btn--sm ${isActive(pathname, "/paralegals") ? "is-active" : ""}`} href="/paralegals">
+            Paralegals
+          </Link>
+
           <Link className={`btn btn--secondary btn--sm ${isActive(pathname, "/workshop") ? "is-active" : ""}`} href="/workshop">
             Workshops
           </Link>

--- a/content/insights/ai-anxiety-law-firms.mdx
+++ b/content/insights/ai-anxiety-law-firms.mdx
@@ -1,0 +1,89 @@
+---
+title: "AI Anxiety in Law: What Small PI Firms Actually Need to Know"
+description: "Small PI firms are worried about AI replacing lawyers. Here's what's real, what's hype, and why AI-assisted with human oversight is the safe middle ground."
+date: "2026-02-16"
+tags: ["ai tools", "pi firms", "legal ops"]
+---
+
+<h2>The Post That Started a Conversation</h2>
+
+<p>A solo practitioner posted on Reddit this week: "I'm having my AI freakout moment. Two-attorney PI shop, and I can't tell if I need to overhaul everything or if this is just noise."</p>
+
+<p>The thread exploded. Hundreds of comments from attorneys at firms just like this one — small PI and trusts-and-estates practices trying to figure out if AI is about to make them obsolete, or if the whole thing is overblown.</p>
+
+<p>If you've had that same 2 AM thought, you're not alone. And the honest answer is more nuanced than most AI vendors want to admit.</p>
+
+<h2>What AI Can Actually Do for Small PI Firms Right Now</h2>
+
+<p>Let's separate the signal from the noise. In early 2026, AI tools for legal work fall into a few practical categories:</p>
+
+<p><strong>Document review and summarization.</strong> AI can read through hundreds of pages of medical records, deposition transcripts, or discovery documents and pull out key information. This is real, it works, and it saves significant time.</p>
+
+<p><strong>Drafting assistance.</strong> Tools can generate first drafts of demand letters, discovery responses, and routine correspondence. The output needs human review — sometimes heavy editing — but the starting point is better than a blank page.</p>
+
+<p><strong>Data extraction.</strong> Pulling dates, provider names, diagnosis codes, and treatment details from medical records is where AI shines. What used to take a paralegal 20 or more hours per case can be reduced to a fraction of that time — when the extraction is verified by a trained human.</p>
+
+<p><strong>Research support.</strong> Legal research tools powered by AI can surface relevant case law faster. But every experienced attorney knows that the judgment call — which cases actually apply, which arguments hold water — still requires a legal mind.</p>
+
+<h2>What AI Cannot Do (Despite What the Headlines Say)</h2>
+
+<p>Here's where the anxiety usually comes from: a misunderstanding of what AI is actually replacing.</p>
+
+<p><strong>AI doesn't replace legal judgment.</strong> No AI tool can evaluate whether a case is worth pursuing, negotiate with an adjuster who's low-balling, or counsel a client through a difficult decision. These require empathy, experience, and professional responsibility — things that don't come in a software subscription.</p>
+
+<p><strong>AI hallucinates.</strong> This is not a theoretical risk. <a href="https://www.americanbar.org/groups/law_practice/resources/tech-report/" target="_blank" rel="noopener">The American Bar Association has documented cases</a> where attorneys submitted AI-generated briefs containing fabricated case citations. For a PI firm handling real clients with real injuries, an unverified AI output isn't just embarrassing — it's malpractice territory.</p>
+
+<p><strong>AI doesn't understand your client's story.</strong> A motor vehicle accident case isn't just a collection of medical records and police reports. It's a person whose life changed. The narrative that wins at mediation or trial comes from a lawyer who listened, not an algorithm that summarized.</p>
+
+<h2>The Real Risk for Small Firms Isn't AI — It's Inaction</h2>
+
+<p>Here's the part most AI-anxiety articles miss: the bigger threat to a two-attorney PI firm isn't that AI will replace you. It's that you'll keep doing everything manually while the firm down the street figures out how to handle twice the caseload with the same headcount.</p>
+
+<p>The math is straightforward. If your paralegal spends 25 hours building a medical chronology for one case, and a competitor's paralegal spends 8 hours because AI handles the initial extraction and a trained human verifies it, that competitor can take on more cases at the same quality level.</p>
+
+<p>This isn't about replacing people. It's about what those people spend their time on.</p>
+
+<h2>The "AI-Assisted, Human-Verified" Middle Ground</h2>
+
+<p>The attorneys in that Reddit thread who seemed most comfortable weren't the ones who went all-in on AI, and they weren't the ones who ignored it entirely. They were the ones who found a middle path.</p>
+
+<p>That middle path looks like this:</p>
+
+<ul>
+  <li><strong>AI handles the extraction and first pass.</strong> Pull data from medical records, flag key dates, organize documents by provider and date of service.</li>
+  <li><strong>A trained human verifies everything.</strong> Every AI output gets reviewed by someone who knows what a PI case file should look like — not a generalist, not a freelancer between gigs, but a dedicated paralegal with PI-specific training.</li>
+  <li><strong>The attorney makes the judgment calls.</strong> With organized, verified information in front of them, lawyers can focus on case strategy, client communication, and the work that actually moves settlements forward.</li>
+</ul>
+
+<p>This is exactly how our team approaches operational support for PI firms. Our paralegal pods use AI tools to accelerate extraction and organization, but every output is reviewed by dedicated paralegals trained specifically in personal injury workflows. It's not AI-only. It's not manual-only. It's the approach that actually works for firms that can't afford errors.</p>
+
+<h2>A Practical Framework for Your Firm</h2>
+
+<p>If you're a small PI firm trying to figure out your AI strategy, here's a realistic starting point:</p>
+
+<h3>Step 1: Identify your highest-volume repetitive tasks</h3>
+
+<p>For most PI firms, this is medical records organization, intake data entry, and routine correspondence. These are the tasks where AI assistance delivers the most time savings.</p>
+
+<h3>Step 2: Evaluate the error tolerance</h3>
+
+<p>Some tasks are low-risk if imperfect (a first draft of a status letter). Others are high-stakes (a medical chronology that goes to opposing counsel). Match your approach to the risk: AI-only for low-stakes drafts, AI-assisted with human verification for anything that touches case substance.</p>
+
+<h3>Step 3: Don't build the infrastructure yourself</h3>
+
+<p>A two-attorney firm doesn't need to become a tech company. You don't need to evaluate fifteen AI tools, train your staff on each one, and build quality-control workflows from scratch. This is where working with a service that has already built these systems — with proper SOC 2 and HIPAA compliance baked in — makes more sense than DIY.</p>
+
+<h3>Step 4: Measure what matters</h3>
+
+<p>Track time-to-completion on key tasks before and after any change. If medical chronologies that took 25 hours now take 8 with the same accuracy, that's a real result. If your intake response time drops because your team isn't buried in data entry, that's measurable growth.</p>
+
+<h2>The Bottom Line</h2>
+
+<p>The AI anxiety in that Reddit thread was real, and it was valid. Small PI firms have every right to be cautious — this is people's livelihoods and their clients' cases.</p>
+
+<p>But the answer isn't to panic, and it isn't to pretend AI doesn't exist. The firms that will thrive are the ones that adopt AI as a tool — with human oversight as a non-negotiable — and redirect the time savings toward the work that actually requires a lawyer.</p>
+
+<p>Your clients hired you for your judgment, your advocacy, and your ability to fight for their recovery. No algorithm is coming for that.</p>
+
+---
+*Need a paralegal team that already knows how to use AI? [Counterbench Paralegals](/paralegals) — dedicated pods for PI firms. Live in 2-3 weeks.*

--- a/content/insights/hiring-first-paralegal-remote-ai.mdx
+++ b/content/insights/hiring-first-paralegal-remote-ai.mdx
@@ -1,0 +1,97 @@
+---
+title: "Hiring Your First Paralegal? Why Small Firms Are Going Remote and AI-Powered"
+description: "Small law firms hiring their first paralegal face tough budget and training decisions. AI-powered remote paralegal services offer a smarter path forward."
+date: "2026-02-20"
+tags: ["hiring", "staffing", "ai tools"]
+---
+
+<p>There's a moment in every small firm's growth that feels like stepping off a cliff: hiring your first paralegal.</p>
+
+<p>You've been running cases solo — or with minimal help — for a year or more. You're turning down work, missing deadlines by inches, and spending your evenings on tasks that don't require a law degree. The math is obvious: you need help. But the hiring decision is anything but simple.</p>
+
+<p>A recent post from a plaintiff's employment attorney captures this tension perfectly. After eighteen months of building a practice, they're ready to bring on their first paralegal or legal assistant. The questions are familiar to anyone who's been in that position: What's a reasonable salary? What should the role look like? How do you train someone when you barely have time to train yourself? And the big one — what if it doesn't work out?</p>
+
+<p>These are the right questions. But the answer doesn't have to be a traditional full-time hire.</p>
+
+<h2>The Real Cost of Your First In-House Paralegal</h2>
+
+<p>Let's lay out the numbers honestly, because this is where most small firms either overshoot or underinvest.</p>
+
+<p>In competitive markets, an experienced paralegal commands $55,000 to $75,000 in salary. Add employer payroll taxes, health insurance, workers' compensation, and even modest benefits, and your all-in cost is $70,000 to $95,000 annually. For a firm billing $350,000 to $500,000 in revenue, that's 15 to 25 percent of gross revenue committed to a single hire before they've completed their first assignment.</p>
+
+<p>Then there's the overhead you don't see on the job posting: a workstation, practice management software licenses, training time (your time, which has a very real opportunity cost), HR compliance, and the management bandwidth to supervise someone's work product when you're also the firm's only revenue generator.</p>
+
+<p>None of this means hiring in-house is wrong. It means the decision deserves more than a gut feeling about "being ready."</p>
+
+<h2>The Training and Supervision Gap</h2>
+
+<p>Here's what the job postings don't tell you: a paralegal is only as effective as the systems they're working within.</p>
+
+<p>When a large firm hires a paralegal, that person walks into established workflows, documented procedures, templates, and a supervision structure with senior paralegals and associates. When a solo or small firm hires their first paralegal, that person walks into... whatever the attorney has been doing, which is usually a mix of improvisation and muscle memory.</p>
+
+<p>This creates a painful onboarding cycle. The attorney spends weeks teaching processes that aren't really documented, answering questions that keep pulling them out of billable work, and reviewing drafts that don't match their expectations because those expectations were never clearly communicated. Three months in, the attorney is working harder than before the hire, and the paralegal feels unsupported.</p>
+
+<p>It's not a people problem. It's an infrastructure problem. And it's the reason a lot of first paralegal hires don't last.</p>
+
+<p>The firms that navigate this well build the systems first — intake workflows, document templates, communication protocols, task checklists — and then plug a person into those systems. The order matters. But building those systems takes time that most small firm attorneys don't have.</p>
+
+<h2>The Remote Paralegal Alternative</h2>
+
+<p>Remote paralegal work has matured significantly. What was once a niche arrangement — typically a freelancer handling overflow work — has evolved into a legitimate staffing model with dedicated professionals, structured workflows, and consistent quality.</p>
+
+<p>For a small firm hiring its first support person, remote paralegal services address several of the pain points that make traditional hiring risky.</p>
+
+<p><strong>Flexible cost structure.</strong> Instead of a $70,000+ annual commitment, remote paralegal services typically operate on a per-hour, per-project, or monthly retainer basis. A firm might spend $2,000 to $4,000 per month and get 40 to 80 hours of skilled paralegal work — scaling up during busy periods and down during slow ones. That's cash flow management, not just cost savings.</p>
+
+<p><strong>No training ramp-up.</strong> Remote paralegal services employ people who are already trained. They come with experience across multiple practice areas and firm types. You're not building capability from zero — you're plugging into existing capability.</p>
+
+<p><strong>Reduced management burden.</strong> With a well-structured remote service, the attorney's role shifts from supervisor-trainer to reviewer-delegator. You define the work, receive the output, and review. The day-to-day management of the paralegal's workflow, quality control, and professional development is handled by the service.</p>
+
+<p><strong>Lower risk.</strong> If the arrangement doesn't work, you're not navigating a termination. You adjust the scope or switch services. The emotional and financial cost of a bad fit is dramatically lower.</p>
+
+<h2>Where AI Changes the Calculus</h2>
+
+<p>Remote paralegal services solve the staffing problem. AI solves the efficiency problem. The combination changes the economics of small firm operations in a way that neither does alone.</p>
+
+<p>Here's the practical difference. A traditional paralegal — remote or in-house — can draft a standard demand letter in 60 to 90 minutes. An AI-assisted paralegal working with intelligent templates and case data can produce a comparable first draft in 10 to 15 minutes. The attorney still reviews and refines, but the total cycle time drops dramatically.</p>
+
+<p>Scale that across the repeatable work of a small firm — document drafting, intake processing, discovery organization, correspondence, filing preparation, deadline tracking — and the math shifts in a significant way. Instead of needing 40 hours per week of paralegal time, a firm might achieve the same output in 20 to 25 hours, because the AI layer handles the repetitive, pattern-based work that traditionally consumed most of a paralegal's day.</p>
+
+<p>This isn't about replacing paralegals. It's about amplifying what a paralegal can accomplish in an hour. For a small firm watching every dollar, that amplification is the difference between affordable support and overhead anxiety.</p>
+
+<h2>What to Look for in an AI-Powered Paralegal Service</h2>
+
+<p>Not all remote paralegal services have integrated AI effectively, and not all AI legal tools are designed to work alongside human paralegals. The best solutions combine both — skilled professionals supported by intelligent tools — rather than asking attorneys to manage the AI themselves.</p>
+
+<p>When evaluating options, consider these factors.</p>
+
+<p><strong>Human oversight on every deliverable.</strong> AI produces drafts, not final work product. Any service worth considering should have a qualified paralegal reviewing and refining AI-generated output before it reaches the attorney. The attorney's review is the final quality gate, not the only one.</p>
+
+<p><strong>Practice-area alignment.</strong> AI tools trained on general legal data produce generic output. Look for services that can configure their AI workflows to your practice area, jurisdiction, and firm preferences. A plaintiff's employment firm has different needs than a corporate transactional practice.</p>
+
+<p><strong>Transparent pricing.</strong> Understand exactly what you're paying for. Some services charge per task, others per hour, others on a monthly retainer. The best pricing models align the service's incentives with your firm's outcomes — they should benefit from being efficient, not from billing more hours.</p>
+
+<p><strong>Data security and confidentiality.</strong> Your client data is passing through external systems. Ensure the service has clear data handling policies, encryption standards, and confidentiality agreements that meet your ethical obligations. This is non-negotiable.</p>
+
+<p><strong>Scalability.</strong> Your needs at 15 cases per month are different from your needs at 50. The service should scale smoothly in both directions without requiring you to renegotiate terms or onboard new people every time your volume changes.</p>
+
+<h2>Making the Transition</h2>
+
+<p>If you're a small firm owner standing at the "hire my first paralegal" crossroads, consider this sequence.</p>
+
+<p>First, document your repeatable work. List every task you do regularly that doesn't require attorney judgment — document drafting, calendar management, client follow-ups, filing, research tasks. This becomes your delegation inventory.</p>
+
+<p>Second, start with a defined scope. Don't try to offload everything at once. Pick two or three high-volume, well-defined task types and test the remote AI-powered model. Intake processing and standard document preparation are usually the best starting points because they're high-frequency and highly systematizable.</p>
+
+<p>Third, measure the results. Track your time savings, turnaround times, error rates, and cost per case. After 60 to 90 days, you'll have real data to decide whether to expand the arrangement, supplement it with an in-house hire, or adjust your approach.</p>
+
+<p>This measured approach reduces risk and builds confidence — both in the service and in your own delegation skills, which are a muscle most solo attorneys haven't had to develop.</p>
+
+<h2>The Bottom Line</h2>
+
+<p>Hiring your first paralegal is a milestone, but it doesn't have to mean a $70,000 leap of faith. AI-powered remote paralegal services give small firms access to skilled, scalable support at a fraction of the cost and risk of a traditional hire — with the added efficiency of AI-assisted workflows that make every hour of paralegal time go further.</p>
+
+<p>The firms that grow fastest aren't the ones that hire the most people. They're the ones that build the smartest support infrastructure around the work that matters.</p>
+
+---
+*Need a paralegal team that already knows how to use AI? [Counterbench Paralegals](/paralegals) — dedicated pods for PI firms. Live in 2-3 weeks.*

--- a/content/insights/paralegal-burnout-firm-owner-guide.mdx
+++ b/content/insights/paralegal-burnout-firm-owner-guide.mdx
@@ -1,0 +1,136 @@
+---
+title: "Your Paralegal Just Gave Two Weeks' Notice. Here's What It's Actually Costing You."
+description: "Paralegal burnout isn't a wellness issue — it's a business crisis. Here's what firm owners need to know about the real cost of turnover and how to fix the root causes."
+date: "2026-02-19"
+tags: ["paralegals", "staffing", "legal ops"]
+---
+
+<h2>The Reddit Thread Every Firm Owner Should Read</h2>
+
+<p>A paralegal posted on Reddit this week with two words that should make every managing attorney pay attention: "Wanting out."</p>
+
+<p>Not wanting a new job. Not wanting a raise. Wanting out — of the entire profession. The post described years of 7am-to-6pm days without adequate compensation, workloads that kept growing while staffing stayed flat, and the slow realization that the pace was unsustainable.</p>
+
+<p>The comments were worse. Dozens of experienced paralegals described the same trajectory: initial enthusiasm, gradual overload, eventual breakdown. Some had already left. Others were actively planning their exit. The thread read less like a career discussion and more like an exit interview for an entire profession.</p>
+
+<p>If you manage a PI firm with paralegals, this matters — not because it's sad (though it is), but because paralegal turnover is one of the most expensive problems a small firm faces. And most firm owners dramatically underestimate the cost.</p>
+
+<h2>The Real Cost of Losing a Paralegal (It's Not What You Think)</h2>
+
+<p>When a paralegal gives notice, most firm owners calculate the damage as: recruiting costs plus the salary difference for a replacement. That's the visible number. It's also less than half of the actual impact.</p>
+
+<p>Here's a more complete picture for a PI firm with a paralegal earning $55,000-$65,000 per year:</p>
+
+<p><strong>Direct replacement costs: $15,000-$25,000.</strong> This includes job postings, recruiter fees (typically 15-25% of first-year salary), interview time for attorneys and staff, and background checks. In a market where paralegal unemployment sits at roughly 2%, finding a qualified PI paralegal can take 3-6 months.</p>
+
+<p><strong>Knowledge loss: incalculable, but devastating.</strong> Your departing paralegal knows every active case — the difficult adjusters, the providers who are slow to respond, the clients who need extra communication. That institutional knowledge walks out the door and doesn't come back. The new hire starts from zero on every single file.</p>
+
+<p><strong>Productivity gap: $30,000-$50,000.</strong> Industry data suggests it takes 6-12 months for a new paralegal to reach full productivity at a PI firm. During that ramp-up, cases move slower, more work falls back on attorneys (who should be doing higher-value tasks), and client satisfaction takes a hit.</p>
+
+<p><strong>Case delays and downstream revenue impact: $20,000-$40,000.</strong> When a paralegal with 30 active cases leaves, those cases don't pause. Files need to be transitioned, deadlines re-tracked, and clients re-informed. Some cases inevitably slip — missed follow-ups on medical records, delayed demand submissions, lapsed communication with clients who then call other firms.</p>
+
+<p><strong>Morale damage to remaining staff: hard to quantify, easy to feel.</strong> When one paralegal burns out and leaves, the remaining staff absorbs the caseload (temporarily, management promises). Temporary becomes permanent. The survivors start updating their own resumes. You're now one resignation away from a cascade.</p>
+
+<p>Conservative total: $65,000-$115,000 per paralegal departure. And that's assuming you find a replacement within a reasonable timeframe. In today's legal hiring market, that's far from guaranteed.</p>
+
+<h2>What's Actually Causing the Burnout (It's Not Just Long Hours)</h2>
+
+<p>The Reddit thread about wanting out was revealing because the frustrations went deeper than "I work too many hours." Understanding the root causes matters, because the fix for each one is different.</p>
+
+<h3>Caseload creep without headcount growth</h3>
+
+<p>The most common pattern: firm revenue grows, case volume increases, and the existing team absorbs the additional work without additional hires. A paralegal who started with 20 cases is now managing 40. The standard benchmark in PI is 20-25 active cases per paralegal for quality work. Beyond that, something starts slipping — follow-ups get delayed, records requests fall behind, and client communication becomes reactive instead of proactive.</p>
+
+<p>The firm owner often doesn't see this happening because revenue is up and nobody's complaining yet. Paralegals tend to absorb pressure quietly — until they don't.</p>
+
+<h3>Administrative tasks crowding out substantive work</h3>
+
+<p>This came up repeatedly in multiple Reddit threads: paralegals spending 50-65% of their time on tasks that don't require their training or expertise. Data entry into case management systems. Chasing medical records by phone. Scheduling appointments. Formatting documents.</p>
+
+<p>The paralegal didn't go through certification to do data entry. When the majority of their day is administrative rather than substantive, they disengage — not because they're lazy, but because they're overqualified for the work they're actually doing. It's a role-design problem, not a motivation problem. And when that administrative volume includes tasks like building medical chronologies that could be handled more efficiently, the frustration compounds.</p>
+
+<h3>No path forward</h3>
+
+<p>Several commenters in the burnout thread described hitting a ceiling. They've been at the same firm for years, their responsibilities have grown enormously, but their title, compensation, and decision-making authority haven't changed. The message received: "We need you to do more, but we don't value you more."</p>
+
+<p>In a profession where a career paralegal can earn $50,000-$80,000 depending on market, the financial ceiling is real. But the paralegals who stay tend to be the ones who feel their expertise is respected and utilized — not just their capacity to absorb volume.</p>
+
+<h3>Technology investment without people investment</h3>
+
+<p>A separate Reddit thread this week highlighted a firm that bought new AI software while skipping annual raises. The reaction from the paralegal community was immediate and pointed: "They're investing in replacing us while telling us there's no money for cost-of-living increases."</p>
+
+<p>Whether or not that's the firm's intent, the message received is clear. And it creates a toxic dynamic where staff resists the very tools the firm needs them to adopt — because adopting those tools feels like training their own replacement.</p>
+
+<h2>A Retention Framework That Actually Works for Small Firms</h2>
+
+<p>Large firms throw money at retention: signing bonuses, premium benefits, tuition reimbursement. Small PI firms usually can't match that. But the good news from the research — and from what the Reddit paralegals described wanting — is that money alone isn't what keeps good paralegals. Systems, respect, and manageable workloads matter more.</p>
+
+<h3>Audit your caseload ratios — honestly</h3>
+
+<p>Pull the numbers: how many active cases is each paralegal managing right now? If anyone is above 25, you have a workload problem that no amount of pizza parties or "Employee of the Month" plaques will fix.</p>
+
+<p>The math is unforgiving. At 25 cases, a paralegal can provide proactive client communication, thorough records management, and careful case progression. At 40 cases, they're triaging — doing the minimum on every file and hoping nothing falls through the cracks. The quality of your firm's work product is directly tied to this number.</p>
+
+<p>If the ratio is unsustainable but hiring a full-time paralegal isn't immediately feasible, dedicated operational support can absorb the administrative volume while your paralegals focus on the substantive work they were trained to do.</p>
+
+<h3>Separate administrative work from paralegal work</h3>
+
+<p>The fastest way to improve paralegal satisfaction isn't a raise (though raises help). It's removing the administrative tasks that make them feel like expensive data-entry clerks.</p>
+
+<p>Map every task your paralegals do in a typical week. Separate them into two categories:</p>
+
+<ul>
+  <li><strong>Substantive paralegal work:</strong> Drafting demands, preparing discovery responses, analyzing medical records, communicating case strategy with attorneys, managing case timelines.</li>
+  <li><strong>Administrative work:</strong> CRM data entry, records request follow-up calls, appointment scheduling, document formatting, filing, status update emails.</li>
+</ul>
+
+<p>If more than 40% of their time is in the administrative column, you have a structural problem. That administrative work needs to go somewhere — to a legal assistant, a remote support team, or an intake and administrative pod that handles it at scale.</p>
+
+<h3>Create visibility into career progression</h3>
+
+<p>Even at a 5-person firm, you can create tiers. Paralegal I, Paralegal II, Senior Paralegal — with clear criteria for advancement and meaningful differences in responsibility and compensation at each level. This doesn't need to be elaborate. It needs to exist.</p>
+
+<p>The paralegals who posted about burning out consistently described a lack of forward motion. They weren't just tired — they felt stuck. A clear path, even a modest one, provides a reason to stay.</p>
+
+<h3>Involve your team in technology decisions</h3>
+
+<p>If you're adopting new tools — AI-assisted drafting, automated records requests, improved case management — bring your paralegals into the decision process. Let them test the tools. Let them provide feedback. Frame the technology as something that makes their job easier, not something that makes them expendable.</p>
+
+<p>The firms that get this right see a compound benefit: the technology works better because the people using it daily helped select and configure it, and staff morale improves because they feel included rather than threatened.</p>
+
+<h2>The Warning Signs Most Firm Owners Miss</h2>
+
+<p>Burnout doesn't happen overnight. It builds over months, and by the time a paralegal gives notice, the damage — to them and to your firm — is already done. Here are the early signals:</p>
+
+<ul>
+  <li><strong>Increased errors on routine tasks.</strong> A paralegal who has always been detail-oriented starts making mistakes on records requests, filing deadlines, or client communications. This isn't carelessness — it's cognitive overload.</li>
+  <li><strong>Withdrawal from team interactions.</strong> Someone who used to contribute in case meetings goes quiet. They stop volunteering for projects. Lunch is eaten alone at the desk.</li>
+  <li><strong>Sick days increase.</strong> Burnout manifests physically — headaches, insomnia, stomach problems. A pattern of Monday absences or unexplained sick days is a signal.</li>
+  <li><strong>Decline in client communication quality.</strong> Responses become shorter and less proactive. Follow-ups that used to happen automatically now require reminders. Clients start calling the attorney directly because they can't reach the paralegal.</li>
+  <li><strong>Resistance to new work or process changes.</strong> "That's not going to work" becomes the default response. Not because the idea is bad, but because they have no capacity to absorb anything new.</li>
+</ul>
+
+<p>If you're seeing three or more of these signals from the same person, the resignation letter is probably already drafted. The window to intervene is smaller than you think.</p>
+
+<h2>The Business Case for Prevention</h2>
+
+<p>Here's the math that should change how you think about paralegal retention:</p>
+
+<p>Investing $15,000 per year in retention — through a combination of competitive compensation adjustments, workload management (potentially including operational support to reduce administrative burden), and modest career development — costs less than one-fifth of a single paralegal departure.</p>
+
+<p>This is the model our team uses with PI firms: dedicated paralegal pods handle the high-volume operational work — medical records, intake data processing, case management tasks — so your in-house paralegals can focus on substantive work instead of drowning in administrative volume. It's not about replacing your team. It's about giving them a workload they can sustain.</p>
+
+<p>The firms that keep their paralegals aren't spending dramatically more on compensation. They're spending less on everything else: less on recruiting, less on training replacements, less on the case delays and quality issues that accompany turnover. The economics of retention aren't just better — they're not even close.</p>
+
+<h2>The Bottom Line</h2>
+
+<p>The paralegal who posted about wanting out wasn't describing a personal failing. They were describing a system that treats skilled professionals as infinitely expandable resources — give them more cases, more tasks, more responsibility, without adjusting the support structure around them.</p>
+
+<p>If your firm's growth strategy depends on your paralegals absorbing ever-increasing caseloads without additional support, you're not building a scalable practice. You're building a countdown to your next resignation.</p>
+
+<p>The fix isn't complicated. Measure caseload ratios. Separate administrative work from paralegal work. Create a path forward. And invest in the operational infrastructure — whether that's additional hires, remote support, or better systems — that lets your best people do their best work.</p>
+
+<p>Your paralegals aren't asking for luxury. They're asking for sustainability. The firms that provide it will keep their best people. The firms that don't will keep posting job listings.</p>
+
+---
+*Need a paralegal team that already knows how to use AI? [Counterbench Paralegals](/paralegals) — dedicated pods for PI firms. Live in 2-3 weeks.*

--- a/content/insights/paralegal-outsourcing.mdx
+++ b/content/insights/paralegal-outsourcing.mdx
@@ -1,0 +1,223 @@
+---
+title: "Paralegal Outsourcing: What PI Firms Need to Know Before Making the Switch"
+description: "Paralegal outsourcing can cut overhead 40–60% and eliminate the ramp-time risk of in-house hires. Here's how PI firms evaluate, implement, and get results from outsourced paralegal support."
+date: "2026-03-29"
+tags: ["outsourcing", "staffing", "pi firms"]
+---
+
+<p>The conversation usually starts the same way: a managing partner at a PI firm has just lost their second paralegal in eighteen months. Or they've got 45 active cases and a paralegal team that keeps hinting they're at capacity. Or they're trying to figure out why their profitability hasn't improved even as revenue has grown.</p>
+
+<p>By the time firms are seriously considering paralegal outsourcing, they've usually already tried the conventional response — post the job, hire someone, wait six months for them to ramp up, repeat. The question they're really asking isn't "should we outsource?" It's "is outsourcing actually better than the cycle we're already in?"</p>
+
+<p>The honest answer: for most PI firms handling 25 or more active cases, outsourced paralegal support compares favorably to in-house staffing on cost, speed, and operational consistency. But only if you understand what it actually is — and what it isn't.</p>
+
+<!-- Key Stats Bar -->
+<div class="not-prose my-10 grid grid-cols-2 sm:grid-cols-4 gap-4">
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">40–60%</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Typical overhead reduction vs. in-house</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">1–2 wks</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Deployment vs. 4–6 wk hiring timeline</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">6–12 mo</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Ramp time eliminated with trained pods</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">$82K+</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Avg. true cost of one in-house departure</p>
+  </div>
+</div>
+
+<!-- Table of Contents -->
+<div class="not-prose my-10 bg-surface border border-gray-200 rounded-xl p-6">
+  <h3 class="text-sm font-semibold text-dark uppercase tracking-wider mb-3">In This Article</h3>
+  <nav class="space-y-2">
+    <a href="#what-it-is" class="block text-sm text-muted hover:text-primary transition-colors">What Paralegal Outsourcing Actually Is</a>
+    <a href="#the-cost-math" class="block text-sm text-muted hover:text-primary transition-colors">The Cost Math: In-House vs. Outsourced</a>
+    <a href="#what-works" class="block text-sm text-muted hover:text-primary transition-colors">What Works Well with Outsourced Support</a>
+    <a href="#what-doesnt" class="block text-sm text-muted hover:text-primary transition-colors">What Doesn't Transfer Well</a>
+    <a href="#choosing" class="block text-sm text-muted hover:text-primary transition-colors">How to Choose an Outsourced Paralegal Partner</a>
+    <a href="#implementation" class="block text-sm text-muted hover:text-primary transition-colors">Implementation: What the First 30 Days Look Like</a>
+  </nav>
+</div>
+
+<h2 id="what-it-is">What Paralegal Outsourcing Actually Is</h2>
+
+<p>The term gets used loosely, and that creates confusion. Paralegal outsourcing — when it's done properly — isn't a freelancer marketplace where you hire individuals by the hour. It's a structured operational model where a firm gets dedicated paralegal support that works inside their systems, follows their processes, and handles specific functions end to end.</p>
+
+<p>The distinction matters because the freelancer model fails in practice. A paralegal who works 10 hours a week for five different firms doesn't have the context, the continuity, or the capacity to manage complex PI files. They're task executors, not case managers.</p>
+
+<p>What works for PI firms is a pod model: a small team of paralegals (or specialists within a dedicated team) assigned to your firm, working in your case management system, building familiarity with your attorneys and case types, and accountable to your outcomes rather than just their task completion rate.</p>
+
+<p>This is fundamentally different from temporary staffing or contract placement. You're not hiring a person — you're engaging an operational function. The provider handles the management, quality control, HR, and continuity. You direct the work and set the standards.</p>
+
+<h2 id="the-cost-math">The Cost Math: In-House vs. Outsourced</h2>
+
+<p>The comparison most firms make is wrong from the start. They compare an outsourced monthly fee to a paralegal's salary — and stop there. That's not an apples-to-apples comparison.</p>
+
+<p>The true cost of an in-house paralegal includes everything the salary doesn't:</p>
+
+<div class="not-prose my-8 overflow-x-auto">
+  <table class="w-full text-sm border border-gray-200 rounded-xl overflow-hidden">
+    <thead>
+      <tr class="bg-surface">
+        <th class="text-left p-4 font-semibold text-dark border-b border-gray-200">Cost Component</th>
+        <th class="text-left p-4 font-semibold text-dark border-b border-gray-200">In-House Paralegal</th>
+        <th class="text-left p-4 font-semibold text-dark border-b border-gray-200">Outsourced Support</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="p-4 border-b border-gray-100">Base compensation</td>
+        <td class="p-4 border-b border-gray-100">$55,000–$75,000/yr</td>
+        <td class="p-4 border-b border-gray-100">Included in monthly fee</td>
+      </tr>
+      <tr class="bg-surface/50">
+        <td class="p-4 border-b border-gray-100">Benefits (health, dental, PTO)</td>
+        <td class="p-4 border-b border-gray-100">$12,000–$18,000/yr</td>
+        <td class="p-4 border-b border-gray-100">Included</td>
+      </tr>
+      <tr>
+        <td class="p-4 border-b border-gray-100">Payroll taxes (FICA, FUTA)</td>
+        <td class="p-4 border-b border-gray-100">$5,000–$7,500/yr</td>
+        <td class="p-4 border-b border-gray-100">Included</td>
+      </tr>
+      <tr class="bg-surface/50">
+        <td class="p-4 border-b border-gray-100">Recruiting and onboarding</td>
+        <td class="p-4 border-b border-gray-100">$8,000–$18,000 per hire</td>
+        <td class="p-4 border-b border-gray-100">$0</td>
+      </tr>
+      <tr>
+        <td class="p-4 border-b border-gray-100">Ramp time (6–12 months at reduced productivity)</td>
+        <td class="p-4 border-b border-gray-100">$15,000–$35,000 per hire</td>
+        <td class="p-4 border-b border-gray-100">Minimal — trained on PI workflows</td>
+      </tr>
+      <tr class="bg-surface/50">
+        <td class="p-4 border-b border-gray-100">Management overhead</td>
+        <td class="p-4 border-b border-gray-100">2–4 hrs/wk of partner time</td>
+        <td class="p-4 border-b border-gray-100">Provider handles</td>
+      </tr>
+      <tr>
+        <td class="p-4 border-b border-gray-100">Turnover risk (every 18–24 months avg.)</td>
+        <td class="p-4 border-b border-gray-100">$82,000–$131,000 when it hits</td>
+        <td class="p-4 border-b border-gray-100">Provider continuity responsibility</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<p>When you add these up, the fully loaded annual cost of an in-house paralegal is $90,000–$115,000, not the $65,000 salary line. And that assumes no turnover. When a paralegal leaves — which happens at an industry average rate of once every 18–24 months at small firms — the cost resets with an $82,000–$131,000 one-time hit layered on top.</p>
+
+<!-- Big Stat Callout -->
+<div class="not-prose my-10 bg-dark rounded-xl p-8 text-center">
+  <p class="text-4xl sm:text-5xl font-bold text-white">$90K–$115K</p>
+  <p class="text-sm sm:text-base text-gray-300 mt-2">True annual cost of one in-house paralegal — before accounting for turnover risk</p>
+</div>
+
+<p>A well-structured outsourced paralegal arrangement for a small-to-mid PI firm runs $3,750–$6,500/month — $45,000–$78,000 annually — with no recruiting costs, no benefits overhead, no ramp time, and no turnover liability. The provider handles backfill continuity if someone leaves.</p>
+
+<p>That's a 20–40% cost reduction on the realistic comparison, not the misleading salary-vs-fee comparison. And it comes with better operational consistency, because the support model is built around your work rather than whoever you could afford to hire last quarter.</p>
+
+<h2 id="what-works">What Works Well with Outsourced Paralegal Support</h2>
+
+<p>Paralegal outsourcing delivers the most value in functions that are high-volume, process-driven, and well-defined. These are also the functions that drain in-house paralegals the most — the volume work that crowds out substantive case development.</p>
+
+<p><strong>Intake processing.</strong> Initial client intake, conflict checks, engagement letter preparation, and case opening workflows follow predictable patterns in PI work. A well-trained remote support team handles this faster and more consistently than a general-purpose paralegal who also manages 30 other cases.</p>
+
+<p><strong>Medical records management.</strong> Requesting, tracking, and organizing medical records is the most time-consuming administrative function in PI case management. Remote specialists who do this exclusively — knowing which hospitals require faxed authorizations, which providers take 90 days to respond, which need follow-up at day 30 — outperform in-house generalists who treat records requests as one of 20 competing priorities.</p>
+
+<p><strong>Discovery coordination.</strong> Interrogatory response tracking, document production organization, and deadline management are exactly the kind of structured, deadline-driven work that outsourced teams excel at. The discovery deadline crisis at most PI firms is fundamentally a capacity problem — not a skill problem. Adding dedicated discovery support resolves it.</p>
+
+<p><strong>Case status reporting.</strong> Weekly status summaries, settlement demand tracking, and file progress updates are time-consuming but straightforward. Outsourced teams integrate directly into your case management system and produce these outputs without consuming your in-house team's hours.</p>
+
+<!-- Pull Quote -->
+<div class="not-prose my-8 bg-blue-50 border-l-4 border-primary rounded-r-lg p-5">
+  <p class="text-dark font-medium leading-relaxed">"The functions that drain your in-house paralegals the most are exactly the ones that transfer best to an outsourced model. High volume, well-defined, deadline-driven."</p>
+</div>
+
+<h2 id="what-doesnt">What Doesn't Transfer Well</h2>
+
+<p>Paralegal outsourcing isn't appropriate for every function. Knowing the limits of the model prevents frustration on both sides.</p>
+
+<p><strong>Attorney-facing substantive work during depositions and hearings.</strong> If you need someone in the room supporting a deposition or trial, a remote team can't fill that role. Some firms supplement with local contract paralegals for these specific needs.</p>
+
+<p><strong>Highly relationship-dependent client work.</strong> When a client has built a strong relationship with a specific paralegal and expects them to answer personal calls, that kind of high-touch relationship management doesn't migrate smoothly to a remote model. For most PI clients — who want updates and responsiveness, not a personal friendship — this isn't the barrier firms expect it to be. But it's worth acknowledging.</p>
+
+<p><strong>Work that requires physical presence.</strong> Courthouse filings, in-person document inspection, local process serving — anything that requires someone to be in a specific location can't be handled remotely. Most firms have local staff or vendor relationships for these needs already.</p>
+
+<p>The practical takeaway: outsourced support works best as the operational backbone that handles volume and process, while your in-house team (whether attorneys or a lean in-house paralegal) handles substantive strategy and relationship management. The hybrid model — in-house for high-touch, outsourced for high-volume — is how the most effective PI firms structure this.</p>
+
+<h2 id="choosing">How to Choose an Outsourced Paralegal Partner</h2>
+
+<p>The quality variance between providers is significant. Evaluating them correctly prevents costly mistakes.</p>
+
+<p><strong>PI specialization is non-negotiable.</strong> A general legal outsourcing firm that also handles real estate closings and corporate work doesn't understand PI workflows. The medical records process, discovery cadence, insurance adjuster dynamics, and settlement timeline pressure are specific to personal injury. Your provider needs to speak that language fluently.</p>
+
+<p><strong>Ask about continuity, not just staffing.</strong> What happens when someone on your support team leaves? How fast is backfill? Does institutional knowledge about your firm transfer? A good provider has a clear answer to this. A bad one says "we'll find you someone good."</p>
+
+<p><strong>Understand the systems integration.</strong> Does the team work in your existing case management system, or do they require data to flow through their platform? The best model is working directly in your systems — Clio, MyCase, Filevine, wherever your cases live — rather than creating a separate data silo you have to reconcile.</p>
+
+<p><strong>Check for dedicated vs. shared resources.</strong> A shared-resource model (where your "support team" is actually a pool that handles requests from multiple firms in a queue) produces slower turnaround and zero institutional knowledge of your cases. Dedicated resources assigned to your firm — people who know your attorneys, your case types, and your preferences — produce materially better outcomes.</p>
+
+<p><strong>References from similar firms.</strong> A PI firm of your size and case volume is the right reference point. General legal firm references tell you very little about how the provider performs on PI-specific workflows.</p>
+
+<h2 id="implementation">Implementation: What the First 30 Days Look Like</h2>
+
+<p>The implementation concern firms raise most often isn't cost — it's disruption. "What happens to our cases while we're transitioning?"</p>
+
+<p>A well-run implementation doesn't disrupt active cases. Here's the typical first-30-day structure:</p>
+
+<div class="not-prose my-10 space-y-4">
+  <div class="flex gap-4 items-start">
+    <div class="shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center">
+      <span class="text-white font-bold text-sm">1</span>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark text-lg mb-1">Week 1: Systems access and orientation</h3>
+      <p class="text-muted">The support team gets access to your case management system, reviews your current active files, and learns your naming conventions, preferred formats, and attorney communication styles. No handoffs yet — just orientation.</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start">
+    <div class="shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center">
+      <span class="text-white font-bold text-sm">2</span>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark text-lg mb-1">Week 2: Parallel handling on new cases</h3>
+      <p class="text-muted">New intake cases run through the outsourced workflow first, with your in-house team reviewing outputs. This surfaces any gaps in process documentation and builds confidence before volume increases.</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start">
+    <div class="shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center">
+      <span class="text-white font-bold text-sm">3</span>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark text-lg mb-1">Weeks 3–4: Full handoff for designated functions</h3>
+      <p class="text-muted">The agreed scope — intake, medical records, discovery coordination, or whichever combination fits your situation — transfers to the outsourced team. Your in-house staff redirects to substantive case work and oversight.</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start">
+    <div class="shrink-0 w-10 h-10 bg-primary rounded-full flex items-center justify-center">
+      <span class="text-white font-bold text-sm">4</span>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark text-lg mb-1">Day 30: First review</h3>
+      <p class="text-muted">A structured review of turnaround times, error rates, attorney satisfaction, and case progress. Adjustments to scope or process happen here — before patterns become problems.</p>
+    </div>
+  </div>
+</div>
+
+<p>Most firms report that by week three, their in-house team has noticeable capacity freed up — attorneys are getting case-ready materials faster, and the paralegal who used to spend 40% of their week on intake and records requests is now focused on discovery and settlement development.</p>
+
+<h2>The Bottom Line on Paralegal Outsourcing</h2>
+
+<p>Paralegal outsourcing isn't a shortcut or a compromise. For PI firms with real caseload volume, it's a more cost-effective, more resilient model than the hire-ramp-replace cycle most firms are stuck in.</p>
+
+<p>The firms that get the most out of it are clear about what they're buying: dedicated operational capacity, built around their workflows, with provider accountability for quality and continuity. The firms that struggle treat it like temporary staffing — and get temporary-staffing-quality results.</p>
+
+<p>If your firm is handling 25 or more active PI cases and you're tired of the staffing treadmill, the math on outsourcing is worth running honestly. Compare the full cost of your current model — salary, benefits, turnover risk, ramp time — against a well-structured outsourced support arrangement. The comparison usually clarifies the decision.</p>
+
+---
+*Need a paralegal team that already knows how to use AI? [Counterbench Paralegals](/paralegals) — dedicated pods for PI firms. Live in 2-3 weeks.*

--- a/content/insights/pi-case-management-systems-2026.mdx
+++ b/content/insights/pi-case-management-systems-2026.mdx
@@ -1,0 +1,267 @@
+---
+title: "How to Choose a Case Management System for Your PI Firm in 2026"
+description: "The CMS landscape has changed. Learn what PI firms actually need from case management software and avoid common mistakes when switching systems."
+date: "2026-02-19"
+tags: ["pi firms", "legal ops", "ai tools"]
+---
+
+<p>The moment you post "looking for recommendations on case management systems" in r/LawFirm, you're going to get a dozen different answers. Some swear by the system they've been using for eight years. Others recently switched and are evangelizing. A few are still evaluating options and comparing spreadsheets.</p>
+
+<p>This time around, though, the conversation has shifted. Five years ago, firms were choosing between legacy systems (Clio, LawLab, TimeSolv) based on core features: calendar, document management, contacts, billing. Today, the question isn't just whether the system has these features. It's whether the system has intelligent automation, AI integration, and whether it can work as part of a larger operational framework.</p>
+
+<p>The CMS landscape in 2026 is fundamentally different—and if you're evaluating a new system or wondering whether you should switch, you need to understand what's actually changed and what it means for your PI firm.</p>
+
+<!-- Key Stats Bar -->
+<div class="not-prose my-10 grid grid-cols-2 sm:grid-cols-4 gap-4">
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">AI-Native</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Requirement, not add-on</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">80-90%</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Chronology accuracy</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">5 Must-Haves</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">For PI-specific systems</p>
+  </div>
+  <div class="bg-surface border border-gray-200 rounded-xl p-5 text-center">
+    <p class="text-2xl sm:text-3xl font-bold text-primary">3-4 wks</p>
+    <p class="text-xs sm:text-sm text-muted mt-1">Migration timeline</p>
+  </div>
+</div>
+
+<!-- Table of Contents -->
+<div class="not-prose my-10 bg-surface border border-gray-200 rounded-xl p-6">
+  <h3 class="text-sm font-semibold text-dark uppercase tracking-wider mb-3">In This Article</h3>
+  <nav class="space-y-2">
+    <a href="#ai-native-vs-added" class="block text-sm text-muted hover:text-primary transition-colors">Why 2026 Is Different: AI-Native vs. AI-Added</a>
+    <a href="#five-things" class="block text-sm text-muted hover:text-primary transition-colors">The Five Things PI Firms Actually Need</a>
+    <a href="#common-mistakes" class="block text-sm text-muted hover:text-primary transition-colors">Common Mistakes When Switching Systems</a>
+    <a href="#hidden-problem" class="block text-sm text-muted hover:text-primary transition-colors">The Hidden Problem: Why CMS Alone Isn't Enough</a>
+    <a href="#evaluation-framework" class="block text-sm text-muted hover:text-primary transition-colors">The CMS Evaluation Framework</a>
+    <a href="#operational-layer" class="block text-sm text-muted hover:text-primary transition-colors">The Operational Layer Question</a>
+    <a href="#final-thoughts" class="block text-sm text-muted hover:text-primary transition-colors">Choosing the Right System: Final Thoughts</a>
+  </nav>
+</div>
+
+<h2 id="ai-native-vs-added">Why 2026 Is Different: AI-Native vs. AI-Added</h2>
+
+<p>Five years ago, case management systems were designed around human workflows. AI features were added later as nice-to-haves—document summary generation, automated reminders, basic predictive analytics.</p>
+
+<p>Today, the distinction that matters is whether a system was <strong>designed from the ground up to be AI-native</strong> versus having AI tacked on top of a legacy architecture.</p>
+
+<p>This matters because an AI-native system understands your data differently. It can:</p>
+
+<ul>
+  <li>Learn from your firm's case patterns and automatically suggest next steps based on case type, injury severity, and jurisdiction</li>
+  <li>Flag inconsistencies or missing information in medical records before your paralegal even opens the file</li>
+  <li>Automatically populate case fields from documents instead of requiring manual data entry</li>
+  <li>Generate intelligent summaries of discovery materials that actually reflect what matters in your cases</li>
+  <li>Predict timeline risk and alert you to cases that need attention</li>
+</ul>
+
+<!-- Pull Quote -->
+<div class="not-prose my-8 bg-blue-50 border-l-4 border-primary rounded-r-lg p-5">
+  <p class="text-dark font-medium leading-relaxed">"An AI-native system understands your data differently. A system that just added AI on top of a legacy architecture can't."</p>
+</div>
+
+<p>A system that just added AI on top of a legacy architecture can't do these things. It can generate summaries, but they're generic. It can automate reminders, but they're based on templates, not intelligent understanding of your specific cases.</p>
+
+<p>For PI firms specifically, this distinction is huge. You don't just need a system that stores information. You need a system that understands medical causation, settlement trends, and the specific timeline pressures in PI work.</p>
+
+<h2 id="five-things">The Five Things PI Firms Actually Need From a CMS (And Why You Probably Don't Have All of Them)</h2>
+
+<!-- 5 Must-Haves Checklist -->
+<div class="not-prose my-10 space-y-3">
+  <div class="flex gap-4 items-start bg-surface border border-gray-200 rounded-lg p-4">
+    <div class="shrink-0 w-6 h-6 bg-primary rounded-full flex items-center justify-center mt-0.5">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark">Intelligent Medical Record Management</h3>
+      <p class="text-sm text-muted mt-1">Automatic organization by provider/date, gap flagging, and causation highlighting</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start bg-surface border border-gray-200 rounded-lg p-4">
+    <div class="shrink-0 w-6 h-6 bg-primary rounded-full flex items-center justify-center mt-0.5">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark">Timeline and Chronology Automation</h3>
+      <p class="text-sm text-muted mt-1">Automatic date/event extraction from records with 80-90% accuracy</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start bg-surface border border-gray-200 rounded-lg p-4">
+    <div class="shrink-0 w-6 h-6 bg-primary rounded-full flex items-center justify-center mt-0.5">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark">Settlement and Discovery Workflow Visibility</h3>
+      <p class="text-sm text-muted mt-1">Portfolio-level status view without opening individual cases</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start bg-surface border border-gray-200 rounded-lg p-4">
+    <div class="shrink-0 w-6 h-6 bg-primary rounded-full flex items-center justify-center mt-0.5">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark">Client Communication Integration</h3>
+      <p class="text-sm text-muted mt-1">Email logging, client portal, or automated status updates</p>
+    </div>
+  </div>
+  <div class="flex gap-4 items-start bg-surface border border-gray-200 rounded-lg p-4">
+    <div class="shrink-0 w-6 h-6 bg-primary rounded-full flex items-center justify-center mt-0.5">
+      <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7"/></svg>
+    </div>
+    <div>
+      <h3 class="font-semibold text-dark">PI-Specific Reporting</h3>
+      <p class="text-sm text-muted mt-1">Time to settlement, case type metrics, discovery rates accessible without Excel</p>
+    </div>
+  </div>
+</div>
+
+<h3>1. Intelligent Medical Record Management</h3>
+
+<p>This should be table stakes, but most CMSs treat medical records as files in a folder. They don't understand that in PI work, the records are the case. You need a system that:</p>
+
+<ul>
+  <li>Automatically organizes records by provider, date range, and document type</li>
+  <li>Flags gaps in the medical timeline</li>
+  <li>Highlights causation language and relevant clinical notes</li>
+  <li>Works with your medical records vendors and auto-imports records when they arrive</li>
+  <li>Surfaces related records when you're reviewing a specific document</li>
+</ul>
+
+<p>Most general-purpose CMSs fall short here because they optimize for document management broadly, not medical record intelligence specifically.</p>
+
+<h3>2. Timeline and Chronology Automation</h3>
+
+<p>You shouldn't need a paralegal to manually build case chronologies from hundreds of pages of medical records. Your CMS should be able to extract dates, events, and causation markers automatically, then let your paralegal review and refine them.</p>
+
+<p>This is foundational for PI work. A good CMS does this with 80–90% accuracy, requiring only minor adjustments. A weak one requires your paralegal to manually date-stamp everything.</p>
+
+<h3>3. Settlement and Discovery Workflow Visibility</h3>
+
+<p>You need to see at a glance: What discovery is outstanding? When are responses due? What settlement conversations are in progress? Where are we in the litigation timeline?</p>
+
+<p>A good CMS makes this visible without requiring you to open each case individually. You can see your entire portfolio's status with a few clicks. A weak one requires you to log into each case to check progress.</p>
+
+<h3>4. Client Communication That Reduces Email Chaos</h3>
+
+<p>Most CMSs assume all communication goes through the system (good luck). In reality, your clients email your paralegals directly, your attorneys get calls about timing, and you're managing communication across multiple channels.</p>
+
+<p>A good CMS either:
+  <li>Integrates with your email and automatically logs client communication in the case file</li>
+  <li>Provides a client portal where key updates are pushed automatically (case status, settlement news, document needs)</li>
+  <li>Or both</li>
+</p>
+
+<p>This reduces the number of "Can you check if we got a response yet?" calls and centralizes communication history.</p>
+
+<h3>5. Reporting That Tells You What You Actually Need to Know</h3>
+
+<p>Standard CMS reporting is usually about billing, time tracking, and case status. But the questions you actually ask are: Which cases are moving fastest? What's our average time to settlement by case type? Where are we spending discovery time? What's our close rate on medical authorization requests?</p>
+
+<p>A good CMS surfaces metrics relevant to PI specifically. A weak one gives you generic reporting that requires you to export and manipulate data in Excel.</p>
+
+<h2 id="common-mistakes">Common Mistakes Firms Make When Switching CMS Systems</h2>
+
+<h3>Mistake #1: Expecting the System Alone to Fix Your Operations</h3>
+
+<p>This is the biggest one. Firms switch to a new CMS expecting it to magically improve their process efficiency and case throughput. Then six months in, they realize nothing actually changed—everyone's still doing the same work, just in a different interface.</p>
+
+<p>The system is a tool, not a solution. You also need defined processes, disciplined data entry, and consistent usage. A great CMS with weak operations is still weak. A decent CMS with excellent operations and clear processes is actually pretty powerful.</p>
+
+<h3>Mistake #2: Not Planning for the Migration Phase</h3>
+
+<p>Switching CMSs requires moving historical data, training staff on new workflows, and dealing with the productivity hit during transition. Most firms underestimate this cost.</p>
+
+<p>Budget for: 3–4 weeks of full transition work where productivity dips. One person dedicated to data migration and system configuration. Training time for every team member. And a grace period where people are half-speed because they're learning the new interface while working cases.</p>
+
+<h3>Mistake #3: Picking the System Based on One Feature or a Vendor's Demo</h3>
+
+<p>You saw a great demo of document automation, or one of your attorneys has friends at another firm using a particular system, and that becomes the decision driver. But <strong>PI firms have different needs than real estate firms or criminal defense firms</strong>. A system optimized for corporate transactions might have terrible medical record handling.</p>
+
+<p>The right evaluation process:</p>
+
+<ol>
+  <li>List your top 10 pain points in your current system</li>
+  <li>For each CMS you're considering, test whether it actually solves those specific problems</li>
+  <li>Get a free trial and run a real case through it, not a demo case</li>
+  <li>Talk to existing PI firm customers using the system—not vendor references, but real relationships you can call</li>
+</ol>
+
+<h3>Mistake #4: Assuming the CMS Is the Entire Operational Solution</h3>
+
+<p>This is subtle but important. You need a CMS. But the CMS itself is only responsible for case data, timelines, and visibility. It's not responsible for ensuring data gets into it correctly, that processes are followed consistently, or that cases don't slip through cracks.</p>
+
+<p>That's why firms with the best outcomes don't just have a great CMS. They have an operational layer—whether in-house or outsourced—that ensures:</p>
+
+<ul>
+  <li>Intake data is complete and accurate before cases enter the system</li>
+  <li>Medical records are collected and organized consistently</li>
+  <li>Deadlines are tracked and escalated automatically</li>
+  <li>Discovery is organized and tracked from day one</li>
+  <li>Client communication follows a standard cadence</li>
+</ul>
+
+<p>The best CMS in the world can't force this layer to exist. It just makes the layer's job easier.</p>
+
+<h2 id="hidden-problem">The Hidden Problem: Why a CMS Alone Isn't Enough</h2>
+
+<p>Here's what happens at most PI firms: You implement a new CMS. It's great at tracking cases, organizing documents, and managing timelines. But within six months, you notice something hasn't changed: the paralegals are still doing tons of repetitive work, cases are still stuck waiting for medical records, and discovery isn't flowing as smoothly as it should.</p>
+
+<p>Why? Because the CMS is a visibility tool, not a process tool. It can show you that a case is missing medical records. It can't automatically request them. It can organize records for review. It can't review them. It can track discovery deadlines. It can't organize responsive documents.</p>
+
+<p>In other words: A CMS requires operational work. If that work isn't happening—because your paralegals are overloaded, or because you don't have dedicated resources for case administration—the CMS will sit there looking smart while cases move slowly.</p>
+
+<p>The firms with the best case progression use their CMS differently. They treat it as the information backbone for an operational process. Someone (or some team) owns the intake workflow end-to-end. Someone owns medical records collection and organization. Someone owns discovery management. These roles feed clean data into the CMS, and the CMS provides visibility and coordination.</p>
+
+<p>When you have both the CMS and the operational layer working together, something remarkable happens: Cases move faster. Paralegals spend more time on substantive work. Clients stay informed. Deadlines don't slip. And the CMS becomes genuinely valuable instead of just a better filing cabinet.</p>
+
+<h2 id="evaluation-framework">The CMS Evaluation Framework: What to Actually Test</h2>
+
+<h3>Before You Demo Anything</h3>
+
+<ul>
+  <li>Identify your top three pain points in your current system</li>
+  <li>Document what your ideal workflow would look like for a typical PI case (intake to settlement)</li>
+  <li>List your integrations: email, billing system, document management, accounting software</li>
+  <li>Estimate how much historical data you need to migrate (years of cases)</li>
+</ul>
+
+<h3>During Your Trial or Demo</h3>
+
+<ul>
+  <li><strong>Create a test case from scratch</strong> — Walk through intake, create a case, add medical records, build a chronology, set discovery deadlines. Don't use their demo data.</li>
+  <li><strong>Test the three hardest things your current system does poorly</strong> — If your current system is bad at medical record organization, test that specifically. Don't demo the features that already work.</li>
+  <li><strong>Ask about integration</strong> — Can it pull medical records automatically? Can it log emails? Can it integrate with your billing software? If it can't, what's the workaround?</li>
+  <li><strong>Run a reporting query</strong> — Ask to see: average time to settlement by case type, number of open cases, discovery completion rates. See if the data is accessible without exporting to Excel.</li>
+  <li><strong>Understand pricing transparency</strong> — What's included in the base? What costs extra? How much does per-case data storage cost? Is training included or extra?</li>
+</ul>
+
+<h3>After the Demo</h3>
+
+<ul>
+  <li><strong>Talk to real customers</strong> — Especially PI firms of similar size. Ask them what surprised them (good or bad) about switching. Ask what they wish they'd known.</li>
+  <li><strong>Calculate migration costs honestly</strong> — How much staff time? How much disruption? How long before you're at full productivity?</li>
+  <li><strong>Draft your operational plan</strong> — Don't assume the system alone will work. How will you use it? What processes will you enforce? Who owns making sure data gets into it correctly?</li>
+</ul>
+
+<h2 id="operational-layer">One More Thing: The Operational Layer Question</h2>
+
+<p>As you're evaluating a CMS, think about how it will work with your operational team. Will whoever manages intake, medical records, and discovery find the system easy to use? Does it have API integrations that let you automate some of this work? Does it work well with remote support teams or outsourced operations?</p>
+
+<p>The best CMS is one that your entire team—internal and external, attorneys and staff—can use effectively to stay coordinated on cases. If the interface is clunky, if it doesn't integrate well with your workflow, or if it creates extra work instead of reducing it, you'll resist using it and it won't deliver value.</p>
+
+<h2 id="final-thoughts">Choosing the Right System: Final Thoughts</h2>
+
+<p>In 2026, the CMS landscape is crowded but differentiated. There are genuinely good options designed specifically for PI work. But the system itself isn't the whole solution. <strong>A great CMS plus weak operations still produces weak results. A decent CMS plus disciplined operations produces excellent results.</strong></p>
+
+<p>When you're evaluating, focus on: Does this system understand PI work? Can it integrate with my workflow? Will it reduce or increase friction for my team? And critically: Once I implement this, will I have the operational capacity to use it well?</p>
+
+<p>Answer those questions honestly, and you'll find the right system for your firm. Skip them, and you'll end up with an expensive filing cabinet instead of a competitive advantage.</p>
+
+---
+*Need a paralegal team that already knows how to use AI? [Counterbench Paralegals](/paralegals) — dedicated pods for PI firms. Live in 2-3 weeks.*

--- a/docs/migration/client-announcement-draft.md
+++ b/docs/migration/client-announcement-draft.md
@@ -1,0 +1,42 @@
+# Client Announcement — VerdictOps → CounterbenchAI
+
+**Status**: DRAFT — Philipp reviews and sends. Do not send without Philipp's approval.
+**Audience**: Existing VerdictOps clients (already using both products)
+**Tone**: Direct, no corporate fluff. This is a relationship email, not a press release.
+
+---
+
+## Subject line options
+
+1. A change to how we're set up (and what it means for you)
+2. VerdictOps is becoming CounterbenchAI — here's what changes
+3. One change, nothing disrupts
+
+---
+
+## Email body
+
+Subject: A quick update on VerdictOps
+
+[First name],
+
+Quick update: we're consolidating VerdictOps and CounterbenchAI under one name — CounterbenchAI.
+
+You've been using both already, so practically speaking, nothing changes for you. Same team, same workflows, same paralegal pod. The work continues exactly as it has.
+
+What does change: going forward, the invoice, the brand, and the point of contact will all say CounterbenchAI. If you have any paperwork that references VerdictOps, it's still valid — no need to update anything on your end unless you want to.
+
+The reason for the consolidation: CounterbenchAI is where we're building everything — the AI tools, the paralegal teams, the resources. Keeping two brands separate when you're already using both didn't make sense.
+
+Questions, just reply. Happy to walk through anything.
+
+[Philipp]
+
+---
+
+## Notes for Philipp
+
+- Send individually, not blast — these are relationship clients
+- Personalize the opening line if you can reference a recent matter or interaction
+- If any client has a formal contract referencing VerdictOps, flag it — may need an amendment or addendum
+- Send AFTER counterbench.ai/teams page is live so they have somewhere to land if they click around

--- a/docs/migration/positioning.md
+++ b/docs/migration/positioning.md
@@ -1,0 +1,92 @@
+# CounterbenchAI — Unified Positioning (Post-VerdictOps Merge)
+
+**Decision date**: 2026-04-22
+**What changed**: VerdictOps folded into CounterbenchAI. CounterbenchAI is now both the AI tool layer and the human paralegal layer.
+
+---
+
+## The Core Story
+
+**Before (CounterbenchAI alone)**: "Find the right AI tool for your legal task."
+**Before (VerdictOps alone)**: "Remote paralegal pods for PI firms."
+**After (unified)**: "The AI tools and the team to run them — in one place."
+
+This is the counter-narrative the market needs. Every AI vendor is saying "replace your paralegals." We're saying: we have both — pick the ratio that works for your firm.
+
+---
+
+## Positioning Statement
+
+> CounterbenchAI is the only legal AI platform that combines a curated tool directory with a human paralegal team — so you can use more AI without losing the people who know your cases.
+
+**One-liner**: AI tools + the team to run them.
+
+**For**: PI law firms and legal operations teams
+**Against**: AI-only tools that promise to replace your staff; staffing agencies with no AI layer
+**Proof**: Your clients are already using both products under one roof
+
+---
+
+## Services Naming
+
+**Name**: "Paralegals"
+
+Rationale:
+- 1 word, no interpretation needed
+- Buyer is a firm partner scanning nav — "Paralegals" is exactly what they're thinking
+- Fits as a nav item: Tools | Paralegals | Resources
+
+Nav structure post-merge:
+- Tools (directory, compare, search)
+- Paralegals (formerly VerdictOps — paralegal pods, pricing, discovery call) → /paralegals
+- Resources (prompts, guides, playbooks, newsletter)
+
+---
+
+## Homepage Rewrite — What Changes
+
+### Hero section
+
+**Current headline**: "The right AI tool for your legal task — in seconds."
+**New headline**: "The right AI tools and the team to run them — for PI firms."
+
+**Current subhead**: "Legal teams that use AI to win don't browse five platforms — they match."
+**New subhead**: "Browse 275+ verified tools, match tasks to the right AI, and hire the paralegal team that already knows how to use them."
+
+**New label**: "AI tools + Paralegal Teams"
+
+**Add second CTA below "Browse the full directory"**:
+"Get a paralegal team" → /teams
+
+### New section (below existing features grid, above newsletter)
+
+**Label**: For firms that want more than a directory
+**Heading**: AI tools are only useful if someone knows how to run them.
+**Body**: Most PI firms don't have time to test 12 AI tools and build the workflows to use them. CounterbenchAI Paralegal Teams handle your intake, records, med chronologies, and client communication — with AI already built into how they work. You get the output. We handle the tools.
+**CTA**: "See what's included" → /teams
+**Proof points**:
+- Dedicated paralegal pod, live in 2-3 weeks
+- Intake, records, med chronologies, client communication
+- $3,750/mo — replaces $55K-65K in annual paralegal costs
+- Cancel anytime
+
+---
+
+## What Does NOT Change
+
+- Tool directory — unchanged, still the core product
+- Prompts, guides, playbooks — unchanged
+- Newsletter — unchanged
+- Pricing for tools/resources — unchanged
+
+Only what changes: Teams section is added. Homepage reflects both layers.
+
+---
+
+## The Counter-Narrative (for copy, sales, content)
+
+**What AI vendors say**: "Replace your paralegals with AI."
+**What VerdictOps said**: "Hire remote paralegals instead."
+**What CounterbenchAI now says**: "Use AI tools AND have the team that knows how to run them. You don't have to choose."
+
+This is defensible because it's true. No competitor has both.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "scripts/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "counterbench-ai-main"
   ]
 }


### PR DESCRIPTION
## Summary
- Add /paralegals page with pricing, stats, FAQ, CTA
- Add "Paralegals" nav link to SiteHeader
- Add /paralegals to sitemap (priority 0.8)
- Add VerdictOps services section to homepage
- Migrate 5 VerdictOps blog posts to /insights (rebranded to Counterbench Paralegals)
- Add migration positioning + client announcement docs