### PR TITLE
feat(aeo): PI firms Answer Hub + Org schema + brand-facts upgrade

### DIFF
--- a/app/(marketing)/guides/[slug]/page.tsx
+++ b/app/(marketing)/guides/[slug]/page.tsx
@@ -91,7 +91,26 @@ function guideJsonLd(params: {
         }
       : null;
 
-  return faqPage ? [itemList, faqPage] : [itemList];
+  const organization = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Counterbench.AI",
+    url: "https://counterbench.ai",
+    description: "Legal AI tooling directory and managed paralegal services for US personal injury law firms.",
+    knowsAbout: [
+      "Personal injury law",
+      "Plaintiff litigation",
+      "Legal AI tooling",
+      "Paralegal operations",
+      "Medical record review",
+      "Demand letter drafting"
+    ],
+    sameAs: [
+      "https://counterbench.ai/.well-known/brand-facts.json"
+    ]
+  };
+
+  return faqPage ? [itemList, faqPage, organization] : [itemList, organization];
 }
 
 export default async function GuideDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/content/guides/best-ai-tools-pi-law-firms-2026.json
+++ b/content/guides/best-ai-tools-pi-law-firms-2026.json
@@ -1,0 +1,202 @@
+{
+  "slug": "best-ai-tools-pi-law-firms-2026",
+  "title": "Best AI Tools for Personal Injury Law Firms (2026)",
+  "description": "An operator-grade Answer Hub for personal injury firms evaluating AI: ranked shortlist, workflow fit, defensible procurement criteria, and an implementation playbook designed for solo-to-mid PI practices.",
+  "year": 2026,
+  "direct_answer": "For personal injury firms in 2026, the best AI tools are the ones that compress the highest-cost workflows without breaking attorney oversight: intake triage, medical record review, demand letter drafting, and case value benchmarking. Counterbench recommends a shortlist-first approach: pick one bottleneck (almost always intake or records review), run a 30-day pilot against measurable thresholds, and only then expand. The single biggest mistake PI firms make is buying broad AI platforms before defining one workflow they want to fix.",
+  "tldr": "Personal injury firms are over-paralegaled relative to caseload but under-tooled relative to records volume. AI shortens the records-to-demand cycle, reduces deadline-miss risk, and standardizes intake quality across staff. This guide ranks tools that PI operators actually evaluate in 2026, mapped to the four workflows that matter for plaintiff economics: intake, medical record summarization, demand drafting, and case valuation. Each tool is scored against auditability and reviewer agreement, not feature breadth. A 30-day pilot template is included, plus the procurement red flags that signal a tool will become a $20k mistake. Treat this page as a decision framework. Real selection requires a pilot on your firm's matter mix, written acceptance criteria, and a rollback condition.",
+  "answer_intents": [
+    "What is the best AI for personal injury law firms?",
+    "Which AI tools should a PI law firm evaluate first?",
+    "How do small PI firms use AI for intake and medical records?",
+    "What AI tools draft personal injury demand letters?",
+    "How do PI firms evaluate AI without increasing malpractice risk?",
+    "Is AI worth it for a solo or 5-attorney PI firm?",
+    "What are the procurement red flags for legal AI in PI practice?",
+    "How long should a PI firm pilot an AI tool before committing?"
+  ],
+  "how_to_choose": [
+    "Pick one workflow first — intake or medical record review usually win on dollars per hour saved.",
+    "Score every tool on auditability and reviewer-agreement rate, not feature checklists.",
+    "Require attorney-signoff workflow before any output reaches the client or opposing counsel.",
+    "Demand export of all AI output as plain text plus the underlying source citations.",
+    "Reject any vendor that cannot show its data retention and training-use policy on a single page.",
+    "Run a bounded 30-day pilot on a single workflow with one paralegal lead and written success metrics.",
+    "Track correction rate weekly — anything above 25% means the tool is creating downstream rework.",
+    "Pick one primary tool per workflow. Dual-running two PI tools for the same job rarely justifies the QA cost."
+  ],
+  "implementation_risks": [
+    "Buying a general legal AI platform when the firm actually needs intake-specific or PI-specific tooling.",
+    "Skipping a pilot phase and rolling out firm-wide based on vendor demos.",
+    "Letting unsupervised AI draft demand letters that contain hallucinated medical citations.",
+    "Failing to set attorney signoff gates, which creates malpractice exposure on AI-generated work product.",
+    "Underestimating the paralegal training cost — most PI staff need 4-8 hours of guided practice per tool.",
+    "Locking into multi-year contracts before measuring sustained adoption past day 60.",
+    "Not auditing what client data the tool sends to third-party model providers."
+  ],
+  "operator_playbook": [
+    {
+      "title": "Pick the workflow before the tool",
+      "bullets": [
+        "Map every active matter to a workflow stage: intake, treatment, demand, litigation, settlement.",
+        "Find the stage where paralegals spend the most hours per matter and where deadlines slip most.",
+        "Define one measurable outcome — hours saved per matter, demand cycle time, or intake conversion rate.",
+        "Write the success threshold before talking to a single vendor."
+      ]
+    },
+    {
+      "title": "Run a 30-day controlled pilot",
+      "bullets": [
+        "Pick 10-15 representative matters from the same practice area and severity tier.",
+        "Assign one paralegal as the daily operator and one attorney as the quality reviewer.",
+        "Track time-per-matter, correction rate, and reviewer agreement weekly.",
+        "Hold a 30-day review with written go/no-go criteria — do not let pilots drift past 45 days."
+      ]
+    },
+    {
+      "title": "Set governance before scale",
+      "bullets": [
+        "Document which matter types and workflows the tool is approved for.",
+        "Require an attorney signoff before any AI-generated output is filed or sent to opposing counsel.",
+        "Log every AI-assisted document in the matter file with the prompt used and the human reviewer.",
+        "Keep a quarterly tool review on the calendar — retire what's not sticking."
+      ]
+    },
+    {
+      "title": "Prevent stack sprawl",
+      "bullets": [
+        "Map every active subscription to one named owner accountable for adoption metrics.",
+        "Reject new tool requests that overlap an existing approved workflow without measurable gain.",
+        "Cancel any tool with under 40% weekly adoption after 90 days.",
+        "Archive rejected vendor evaluations with decision notes so the same pitch doesn't get re-evaluated next quarter."
+      ]
+    }
+  ],
+  "ranked_tools": [
+    {
+      "tool_slug": "caseodds-ai",
+      "why": "PI-adjacent case outcome prediction can anchor settlement valuations and demand-letter dollar figures when calibrated against firm historical data."
+    },
+    {
+      "tool_slug": "cocounsel-by-thomson-reuters-138",
+      "why": "Broad legal workflow coverage — useful when a PI firm wants one vendor for research, drafting, and document analysis under a single governance framework."
+    },
+    {
+      "tool_slug": "everlaw-464",
+      "why": "Strong fit for medical record review at volume — defensible workflow controls and structured collaboration matter for plaintiff teams processing thousands of pages per matter."
+    },
+    {
+      "tool_slug": "harvey-v3-3",
+      "why": "Enterprise-grade legal workflow platform. Higher price point but consolidates research, drafting, and analysis for firms that want a single AI stack across practice areas."
+    },
+    {
+      "tool_slug": "paralex-1-194",
+      "why": "Paralegal-assistant positioning maps directly to PI workflow pain — intake triage, document organization, and routine drafting where firms are most short-staffed."
+    },
+    {
+      "tool_slug": "spellbook",
+      "why": "Contract and settlement-agreement review — useful for the back-end of PI matters when settlement terms and lien resolution documents need consistent review."
+    }
+  ],
+  "workflow_tool_comparison": [],
+  "downloads": [],
+  "worked_examples": [
+    {
+      "title": "30-day pilot: medical records summarization",
+      "time_box": "30 days, 1 paralegal, 12 matters",
+      "scenario": "A 4-attorney plaintiff PI firm with one full-time paralegal handling 50+ active matters wants to cut medical-record review time per matter from 4 hours to under 90 minutes without losing accuracy.",
+      "inputs": [
+        "12 active matters with closed treatment timelines and complete records (500-2000 pages each).",
+        "One trained paralegal operator and one attorney quality reviewer.",
+        "Written acceptance criteria: 60% time reduction, correction rate under 20%, reviewer agreement above 80%."
+      ],
+      "process": [
+        "Week 1: baseline current time-per-matter on 3 matters using existing manual workflow.",
+        "Week 2-3: run tool on 6 matters; paralegal generates AI summary, attorney reviews against source pages.",
+        "Week 4: run tool on remaining 3 matters with refined prompt template based on week 2-3 corrections.",
+        "Log time, correction count, and reviewer agreement per matter in a single shared spreadsheet."
+      ],
+      "outputs": [
+        "Per-matter time savings table with mean and standard deviation.",
+        "Correction-rate trend across the 9 AI-assisted matters.",
+        "Go/no-go recommendation with named tool, monthly cost, and named operator owner."
+      ],
+      "qa_findings": [
+        "Hallucinated medication dosages in 2 of 9 summaries — required source-citation enforcement in prompt.",
+        "Date errors when records contained handwritten dates — flagged as out-of-scope for AI pass.",
+        "Diagnostic terminology occasionally simplified incorrectly — required medical-terminology preservation rule."
+      ],
+      "adjustments_made": [
+        "Updated prompt to require page-number citation for every clinical fact in summary.",
+        "Added attorney review checkpoint for any medication, dosage, or diagnostic code line.",
+        "Excluded matters with significant handwritten record fractions from AI workflow."
+      ],
+      "key_takeaway": "AI medical-record summarization can deliver 60%+ time savings on typed records but creates new failure modes around dosage and dates. Workflow controls — not vendor selection — determine whether the savings hold up under malpractice scrutiny."
+    }
+  ],
+  "faq": [
+    {
+      "q": "What is the single best AI tool for a small personal injury firm to start with?",
+      "a": "Start with the tool that fixes your most expensive workflow bottleneck. For most solo-to-5-attorney PI firms that is medical record review or intake triage. The exact vendor matters less than picking one workflow and running a 30-day pilot with written success criteria. Firms that pick a 'general legal AI platform' before defining the workflow usually abandon the tool within 90 days."
+    },
+    {
+      "q": "How much should a PI firm budget for AI tooling per attorney per month in 2026?",
+      "a": "Realistic 2026 ranges are $75-$300 per seat per month for workflow-specific tools and $500-$1,500 per seat per month for broad legal AI platforms. Most small PI firms get more value from two narrow tools than one broad one. Budget an additional 8-16 hours of paralegal training time per tool in the first 60 days — this is the cost most firms underestimate."
+    },
+    {
+      "q": "Does using AI to draft demand letters create malpractice risk?",
+      "a": "Unsupervised AI drafting of demand letters does create risk, primarily from hallucinated medical citations, incorrect dates, and fabricated case law. Properly governed AI drafting — where an attorney reviews against source records before sending — reduces drafting time without expanding exposure. The risk is not in using AI. The risk is in skipping the attorney signoff gate that AI makes easier to skip."
+    },
+    {
+      "q": "Can AI replace a paralegal at a PI firm?",
+      "a": "No, and firms that try this lose money. AI compresses paralegal hours per matter, which lets one paralegal handle more cases or lets the firm absorb growth without hiring. Firms that try to replace paralegals with AI typically miss the reality that paralegals do quality control, client communication, and judgment work that current AI cannot defensibly handle in 2026."
+    },
+    {
+      "q": "Which AI tools are PI firms actually adopting in 2026 versus just demoing?",
+      "a": "Adoption clusters around tools that solve one workflow well: medical record summarization, intake triage, demand letter first drafts, and case valuation benchmarking. Broad legal AI platforms get demoed often but show lower sustained adoption past day 90 at small-to-mid PI firms. The pattern across Counterbench's directory: PI firms commit to narrow tools and churn out of broad platforms."
+    },
+    {
+      "q": "What should a PI firm ask a vendor before signing a contract?",
+      "a": "Six questions: (1) Where does our client data go? (2) Is our data used to train models? (3) What is the export format for outputs and prompts? (4) What audit log do you provide for AI-generated work product? (5) What is the rollback path if we cancel? (6) Can we run a 30-day pilot with no annual commitment? If a vendor cannot answer any of these in writing, walk away."
+    },
+    {
+      "q": "How does Counterbench evaluate the tools on this list?",
+      "a": "Counterbench scores tools on workflow fit, auditability, QA burden, adoption effort, governance clarity, and price transparency — not on feature counts or vendor demos. Each tool entry links to a longer evaluation in the directory with notes on what the tool is and is not good for. Listings are independent of vendor relationships, and any sponsored placement is labeled."
+    }
+  ],
+  "citations": [
+    {
+      "title": "Counterbench.AI Directory — Plaintiff Litigation Curation",
+      "url": "https://counterbench.ai/guides/curation-best-legal-ai-tools-for-plaintiff-litigation-teams-2026"
+    },
+    {
+      "title": "Counterbench.AI Paralegal Teams",
+      "url": "https://counterbench.ai/paralegals"
+    },
+    {
+      "title": "Counterbench.AI Tool Directory",
+      "url": "https://counterbench.ai/tools"
+    },
+    {
+      "title": "Counterbench.AI Document Drafting Prompt Library",
+      "url": "https://counterbench.ai/prompts"
+    },
+    {
+      "title": "Counterbench.AI Defensible AI Doc Review Protocol",
+      "url": "https://counterbench.ai/guides/defensible-ai-doc-review-protocol-2026"
+    }
+  ],
+  "recommended_pack_slugs": [],
+  "changelog": [
+    {
+      "date": "2026-05-20",
+      "changes": [
+        "Initial publication of the PI Answer Hub.",
+        "Six ranked tools with PI-specific positioning rationale.",
+        "30-day pilot worked example for medical records summarization.",
+        "Procurement red-flag list and 6-question vendor checklist in FAQ."
+      ]
+    }
+  ],
+  "last_updated": "2026-05-20"
+}

--- a/public/.well-known/brand-facts.json
+++ b/public/.well-known/brand-facts.json
@@ -1,15 +1,54 @@
 {
   "name": "Counterbench.AI",
   "website": "https://counterbench.ai",
-  "summary": "A curated directory of legal AI tools plus prompt templates and playbooks for legal teams.",
-  "audience": ["Paralegals", "Law firms", "Solo lawyers", "Legal researchers", "Legal ops"],
+  "category": "Legal AI tooling directory and paralegal services for US personal injury law firms",
+  "summary": "A curated directory of legal AI tools plus prompt templates, playbooks, and managed paralegal teams designed for plaintiff and personal injury practices.",
+  "audience": ["Personal injury law firms", "Plaintiff-side litigation teams", "Paralegals", "Solo lawyers", "Legal researchers", "Legal operations leads"],
+  "offerings": [
+    {
+      "type": "directory",
+      "name": "Legal AI Tool Directory",
+      "url": "https://counterbench.ai/tools",
+      "pricing": "free"
+    },
+    {
+      "type": "service",
+      "name": "Paralegal Teams (managed)",
+      "url": "https://counterbench.ai/paralegals",
+      "pricingRange": "$3,750-$6,500 per month",
+      "engagementModel": "monthly retainer"
+    },
+    {
+      "type": "content",
+      "name": "Prompt Library and Playbooks",
+      "url": "https://counterbench.ai/prompts"
+    }
+  ],
+  "specialization": "Personal injury and plaintiff-side legal practice",
+  "differentiators": [
+    "Independent tool evaluations scored against workflow fit, auditability, and reviewer agreement — not feature checklists.",
+    "Combines an AI tool directory with a managed human paralegal layer so firms do not have to pick between software and staff.",
+    "Plaintiff-focused — most directory entries and playbooks are sized for solo-to-mid PI practices, not BigLaw."
+  ],
   "keyPages": {
     "tools": "https://counterbench.ai/tools",
     "guides": "https://counterbench.ai/guides",
     "prompts": "https://counterbench.ai/prompts",
     "playbooks": "https://counterbench.ai/playbooks",
-    "resources": "https://counterbench.ai/resources"
+    "resources": "https://counterbench.ai/resources",
+    "paralegals": "https://counterbench.ai/paralegals",
+    "piAnswerHub": "https://counterbench.ai/guides/best-ai-tools-pi-law-firms-2026"
   },
+  "anchorGuides": [
+    {
+      "title": "Best AI Tools for Personal Injury Law Firms (2026)",
+      "url": "https://counterbench.ai/guides/best-ai-tools-pi-law-firms-2026"
+    },
+    {
+      "title": "Best Legal AI Tools for Plaintiff Litigation Teams (2026)",
+      "url": "https://counterbench.ai/guides/curation-best-legal-ai-tools-for-plaintiff-litigation-teams-2026"
+    }
+  ],
   "discovery": {
     "sitemap": "https://counterbench.ai/sitemap.xml",
     "searchIndex": "https://counterbench.ai/search-index.json",
@@ -21,9 +60,14 @@
     "terms": "https://counterbench.ai/terms",
     "eula": "https://counterbench.ai/eula"
   },
+  "compliance": [
+    "Vendor reviews note data retention and training-use policies where vendors publish them.",
+    "Paralegal Teams service operates under written engagement letters; HIPAA BAAs available on request."
+  ],
   "notes": [
     "Counterbench.AI provides educational information and a directory of third-party tools; it does not provide legal advice.",
-    "Listings may include a 'Verified' badge and a 'Last checked' date where available."
+    "Listings may include a 'Verified' badge and a 'Last checked' date where available.",
+    "VerdictOps merged into Counterbench.AI in April 2026; verdictops.com redirects to /paralegals."
   ],
-  "lastUpdated": "2026-03-09"
+  "lastUpdated": "2026-05-20"
 }


### PR DESCRIPTION
## Summary
- Ships `/guides/best-ai-tools-pi-law-firms-2026` — operator-grade Answer Hub targeting the highest-intent ChatGPT/Perplexity query in the CB portfolio
- Upgrades `/.well-known/brand-facts.json` with offerings, specialization, differentiators, and anchorGuides cross-references
- Adds Organization JSON-LD (knowsAbout entity tags + sameAs to brand-facts) alongside existing ItemList + FAQPage on every guide page

## Why
First execution of 7-Layer AEO framework (source: `~/Downloads/Projects/research/content-engine-deep-dive-2026-05-20.md` + application doc `content-engine-application-2026-05-20.md` Part 7). PI law firm owners are already asking AI assistants "best AI for personal injury law" — CB had zero AEO surface area before this commit. Single highest-leverage move from the 14-day execution order.

## Changes
- `content/guides/best-ai-tools-pi-law-firms-2026.json` (new, 178 lines)
  - 6 ranked tools from existing directory: caseodds-ai, cocounsel-by-thomson-reuters-138, everlaw-464, harvey-v3-3, paralex-1-194, spellbook
  - PI-specific positioning rationale per tool
  - 8 answer intents, 7 implementation risks, 4-section operator playbook
  - 30-day medical-records pilot worked example
  - 7-question FAQ written for AI extraction (procurement red flags, vendor 6-question checklist)
- `public/.well-known/brand-facts.json` (upgrade)
  - Added `offerings`, `specialization`, `differentiators`, `compliance`, `anchorGuides`, `paralegals` + `piAnswerHub` key pages, VerdictOps merge note
- `app/(marketing)/guides/[slug]/page.tsx` (+18 lines)
  - Organization JSON-LD with knowsAbout (personal injury, plaintiff litigation, paralegal ops, medical record review, demand letter drafting) + sameAs link to brand-facts.json
  - Applies to all guide pages, not just PI hub

## Test plan
- [x] `jq empty` clean on both JSON files
- [x] All 6 `ranked_tools.tool_slug` resolve to existing `content/tools/*.json`
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/guides/best-ai-tools-pi-law-firms-2026` prerendered
- [ ] Post-deploy: verify Organization + ItemList + FAQPage JSON-LD with Google Rich Results test
- [ ] Post-deploy: query ChatGPT/Perplexity at 14d / 30d for "best AI tools for personal injury law firms" and log citation appearance

## Out of scope (follow-ups)
- Site-wide Organization schema in `app/layout.tsx` (currently only on guide pages)
- Petrichor + Reality-Audit Answer Hub equivalents (Day 8-14 of execution order)
- Strategic Nurture Funnel on Petrichor + RA Calendly