### PR TITLE
feat(receptionist): admin CRUD + sales motion lock + launch script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,11 @@ DATABASE_URL=
 
 # Resend email
 RESEND_API_KEY=
-RESEND_FROM=noreply@verdictops.com
+RESEND_FROM=noreply@counterbench.ai
+
+# Remote Receptionist
+# Email-to-SMS gateway for fast attorney alerts (e.g. 5551234567@vtext.verizon.net). Optional.
+ATTORNEY_SMS_EMAIL=
+# Admin API key for /api/admin/receptionist/firms CRUD. Required.
+# Generate with: openssl rand -hex 32
+ADMIN_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ out/
 
 # env
 .env
+.env.local
 .env.*.local
+*.scratch
 
 # logs
 npm-debug.log*

--- a/app/(marketing)/guides/[slug]/page.tsx
+++ b/app/(marketing)/guides/[slug]/page.tsx
@@ -91,7 +91,26 @@ function guideJsonLd(params: {
         }
       : null;
 
-  return faqPage ? [itemList, faqPage] : [itemList];
+  const organization = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Counterbench.AI",
+    url: "https://counterbench.ai",
+    description: "Legal AI tooling directory and managed paralegal services for US personal injury law firms.",
+    knowsAbout: [
+      "Personal injury law",
+      "Plaintiff litigation",
+      "Legal AI tooling",
+      "Paralegal operations",
+      "Medical record review",
+      "Demand letter drafting"
+    ],
+    sameAs: [
+      "https://counterbench.ai/.well-known/brand-facts.json"
+    ]
+  };
+
+  return faqPage ? [itemList, faqPage, organization] : [itemList, organization];
 }
 
 export default async function GuideDetailPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/app/api/admin/receptionist/firms/[id]/route.ts
+++ b/app/api/admin/receptionist/firms/[id]/route.ts
@@ -38,10 +38,12 @@ const updateFirmSchema = z
 
 export async function PATCH(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const authErr = checkAuth(req);
   if (authErr) return authErr;
+
+  const { id } = await params;
 
   let body: unknown;
   try {
@@ -62,38 +64,40 @@ export async function PATCH(
     const [updated] = await db
       .update(receptionistFirmsTable)
       .set(parsed.data)
-      .where(eq(receptionistFirmsTable.id, params.id))
+      .where(eq(receptionistFirmsTable.id, id))
       .returning();
     if (!updated) {
       return NextResponse.json({ error: "Firm not found" }, { status: 404 });
     }
-    console.info({ event: "admin_firm_updated", firmId: params.id });
+    console.info({ event: "admin_firm_updated", firmId: id });
     return NextResponse.json({ firm: updated });
   } catch (err) {
-    console.error({ event: "admin_firm_update_failed", err, firmId: params.id });
+    console.error({ event: "admin_firm_update_failed", err, firmId: id });
     return NextResponse.json({ error: "Failed to update firm" }, { status: 500 });
   }
 }
 
 export async function DELETE(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
   const authErr = checkAuth(req);
   if (authErr) return authErr;
 
+  const { id } = await params;
+
   try {
     const [deleted] = await db
       .delete(receptionistFirmsTable)
-      .where(eq(receptionistFirmsTable.id, params.id))
+      .where(eq(receptionistFirmsTable.id, id))
       .returning();
     if (!deleted) {
       return NextResponse.json({ error: "Firm not found" }, { status: 404 });
     }
-    console.info({ event: "admin_firm_deleted", firmId: params.id });
-    return NextResponse.json({ deleted: true, id: params.id });
+    console.info({ event: "admin_firm_deleted", firmId: id });
+    return NextResponse.json({ deleted: true, id });
   } catch (err) {
-    console.error({ event: "admin_firm_delete_failed", err, firmId: params.id });
+    console.error({ event: "admin_firm_delete_failed", err, firmId: id });
     return NextResponse.json({ error: "Failed to delete firm" }, { status: 500 });
   }
 }

--- a/app/api/admin/receptionist/firms/[id]/route.ts
+++ b/app/api/admin/receptionist/firms/[id]/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { receptionistFirmsTable } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function checkAuth(req: Request): NextResponse | null {
+  const expected = process.env.ADMIN_API_KEY;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Admin API not configured (ADMIN_API_KEY missing)" },
+      { status: 503 }
+    );
+  }
+  const provided = req.headers.get("x-admin-key");
+  if (provided !== expected) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+const updateFirmSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    phoneNumber: z.string().min(8).optional(),
+    attorneyEmail: z.string().email().optional(),
+    attorneyPhone: z.string().min(8).optional(),
+    caseTypes: z.string().nullable().optional(),
+    callbackTime: z.string().optional(),
+    active: z.enum(["true", "false"]).optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, {
+    message: "At least one field required",
+  });
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = updateFirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [updated] = await db
+      .update(receptionistFirmsTable)
+      .set(parsed.data)
+      .where(eq(receptionistFirmsTable.id, params.id))
+      .returning();
+    if (!updated) {
+      return NextResponse.json({ error: "Firm not found" }, { status: 404 });
+    }
+    console.info({ event: "admin_firm_updated", firmId: params.id });
+    return NextResponse.json({ firm: updated });
+  } catch (err) {
+    console.error({ event: "admin_firm_update_failed", err, firmId: params.id });
+    return NextResponse.json({ error: "Failed to update firm" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  try {
+    const [deleted] = await db
+      .delete(receptionistFirmsTable)
+      .where(eq(receptionistFirmsTable.id, params.id))
+      .returning();
+    if (!deleted) {
+      return NextResponse.json({ error: "Firm not found" }, { status: 404 });
+    }
+    console.info({ event: "admin_firm_deleted", firmId: params.id });
+    return NextResponse.json({ deleted: true, id: params.id });
+  } catch (err) {
+    console.error({ event: "admin_firm_delete_failed", err, firmId: params.id });
+    return NextResponse.json({ error: "Failed to delete firm" }, { status: 500 });
+  }
+}

--- a/app/api/admin/receptionist/firms/route.ts
+++ b/app/api/admin/receptionist/firms/route.ts
@@ -79,6 +79,10 @@ export async function POST(req: Request) {
         callbackTime: parsed.data.callbackTime ?? "30 minutes",
       })
       .returning();
+    if (!created) {
+      console.error({ event: "admin_firm_create_no_row" });
+      return NextResponse.json({ error: "Insert returned no row" }, { status: 500 });
+    }
     console.info({
       event: "admin_firm_created",
       firmId: created.id,

--- a/app/api/admin/receptionist/firms/route.ts
+++ b/app/api/admin/receptionist/firms/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { db } from "@/lib/db";
+import { receptionistFirmsTable } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+
+// Force dynamic — DB-backed admin route; must not pre-render at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function checkAuth(req: Request): NextResponse | null {
+  const expected = process.env.ADMIN_API_KEY;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Admin API not configured (ADMIN_API_KEY missing)" },
+      { status: 503 }
+    );
+  }
+  const provided = req.headers.get("x-admin-key");
+  if (provided !== expected) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
+}
+
+const createFirmSchema = z.object({
+  name: z.string().min(1),
+  phoneNumber: z.string().min(8), // E.164 expected: "+16175550100"
+  attorneyEmail: z.string().email(),
+  attorneyPhone: z.string().min(8),
+  caseTypes: z.string().optional(),
+  callbackTime: z.string().optional(),
+});
+
+export async function GET(req: Request) {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  try {
+    const firms = await db
+      .select()
+      .from(receptionistFirmsTable)
+      .orderBy(desc(receptionistFirmsTable.createdAt));
+    return NextResponse.json({ firms });
+  } catch (err) {
+    console.error({ event: "admin_firms_list_failed", err });
+    return NextResponse.json({ error: "Failed to list firms" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  const authErr = checkAuth(req);
+  if (authErr) return authErr;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = createFirmSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", issues: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const [created] = await db
+      .insert(receptionistFirmsTable)
+      .values({
+        name: parsed.data.name,
+        phoneNumber: parsed.data.phoneNumber,
+        attorneyEmail: parsed.data.attorneyEmail,
+        attorneyPhone: parsed.data.attorneyPhone,
+        caseTypes: parsed.data.caseTypes ?? null,
+        callbackTime: parsed.data.callbackTime ?? "30 minutes",
+      })
+      .returning();
+    console.info({
+      event: "admin_firm_created",
+      firmId: created.id,
+      name: created.name,
+    });
+    return NextResponse.json({ firm: created }, { status: 201 });
+  } catch (err) {
+    console.error({ event: "admin_firm_create_failed", err });
+    return NextResponse.json({ error: "Failed to create firm" }, { status: 500 });
+  }
+}

--- a/content/guides/best-ai-tools-pi-law-firms-2026.json
+++ b/content/guides/best-ai-tools-pi-law-firms-2026.json
@@ -1,0 +1,202 @@
+{
+  "slug": "best-ai-tools-pi-law-firms-2026",
+  "title": "Best AI Tools for Personal Injury Law Firms (2026)",
+  "description": "An operator-grade Answer Hub for personal injury firms evaluating AI: ranked shortlist, workflow fit, defensible procurement criteria, and an implementation playbook designed for solo-to-mid PI practices.",
+  "year": 2026,
+  "direct_answer": "For personal injury firms in 2026, the best AI tools are the ones that compress the highest-cost workflows without breaking attorney oversight: intake triage, medical record review, demand letter drafting, and case value benchmarking. Counterbench recommends a shortlist-first approach: pick one bottleneck (almost always intake or records review), run a 30-day pilot against measurable thresholds, and only then expand. The single biggest mistake PI firms make is buying broad AI platforms before defining one workflow they want to fix.",
+  "tldr": "Personal injury firms are over-paralegaled relative to caseload but under-tooled relative to records volume. AI shortens the records-to-demand cycle, reduces deadline-miss risk, and standardizes intake quality across staff. This guide ranks tools that PI operators actually evaluate in 2026, mapped to the four workflows that matter for plaintiff economics: intake, medical record summarization, demand drafting, and case valuation. Each tool is scored against auditability and reviewer agreement, not feature breadth. A 30-day pilot template is included, plus the procurement red flags that signal a tool will become a $20k mistake. Treat this page as a decision framework. Real selection requires a pilot on your firm's matter mix, written acceptance criteria, and a rollback condition.",
+  "answer_intents": [
+    "What is the best AI for personal injury law firms?",
+    "Which AI tools should a PI law firm evaluate first?",
+    "How do small PI firms use AI for intake and medical records?",
+    "What AI tools draft personal injury demand letters?",
+    "How do PI firms evaluate AI without increasing malpractice risk?",
+    "Is AI worth it for a solo or 5-attorney PI firm?",
+    "What are the procurement red flags for legal AI in PI practice?",
+    "How long should a PI firm pilot an AI tool before committing?"
+  ],
+  "how_to_choose": [
+    "Pick one workflow first — intake or medical record review usually win on dollars per hour saved.",
+    "Score every tool on auditability and reviewer-agreement rate, not feature checklists.",
+    "Require attorney-signoff workflow before any output reaches the client or opposing counsel.",
+    "Demand export of all AI output as plain text plus the underlying source citations.",
+    "Reject any vendor that cannot show its data retention and training-use policy on a single page.",
+    "Run a bounded 30-day pilot on a single workflow with one paralegal lead and written success metrics.",
+    "Track correction rate weekly — anything above 25% means the tool is creating downstream rework.",
+    "Pick one primary tool per workflow. Dual-running two PI tools for the same job rarely justifies the QA cost."
+  ],
+  "implementation_risks": [
+    "Buying a general legal AI platform when the firm actually needs intake-specific or PI-specific tooling.",
+    "Skipping a pilot phase and rolling out firm-wide based on vendor demos.",
+    "Letting unsupervised AI draft demand letters that contain hallucinated medical citations.",
+    "Failing to set attorney signoff gates, which creates malpractice exposure on AI-generated work product.",
+    "Underestimating the paralegal training cost — most PI staff need 4-8 hours of guided practice per tool.",
+    "Locking into multi-year contracts before measuring sustained adoption past day 60.",
+    "Not auditing what client data the tool sends to third-party model providers."
+  ],
+  "operator_playbook": [
+    {
+      "title": "Pick the workflow before the tool",
+      "bullets": [
+        "Map every active matter to a workflow stage: intake, treatment, demand, litigation, settlement.",
+        "Find the stage where paralegals spend the most hours per matter and where deadlines slip most.",
+        "Define one measurable outcome — hours saved per matter, demand cycle time, or intake conversion rate.",
+        "Write the success threshold before talking to a single vendor."
+      ]
+    },
+    {
+      "title": "Run a 30-day controlled pilot",
+      "bullets": [
+        "Pick 10-15 representative matters from the same practice area and severity tier.",
+        "Assign one paralegal as the daily operator and one attorney as the quality reviewer.",
+        "Track time-per-matter, correction rate, and reviewer agreement weekly.",
+        "Hold a 30-day review with written go/no-go criteria — do not let pilots drift past 45 days."
+      ]
+    },
+    {
+      "title": "Set governance before scale",
+      "bullets": [
+        "Document which matter types and workflows the tool is approved for.",
+        "Require an attorney signoff before any AI-generated output is filed or sent to opposing counsel.",
+        "Log every AI-assisted document in the matter file with the prompt used and the human reviewer.",
+        "Keep a quarterly tool review on the calendar — retire what's not sticking."
+      ]
+    },
+    {
+      "title": "Prevent stack sprawl",
+      "bullets": [
+        "Map every active subscription to one named owner accountable for adoption metrics.",
+        "Reject new tool requests that overlap an existing approved workflow without measurable gain.",
+        "Cancel any tool with under 40% weekly adoption after 90 days.",
+        "Archive rejected vendor evaluations with decision notes so the same pitch doesn't get re-evaluated next quarter."
+      ]
+    }
+  ],
+  "ranked_tools": [
+    {
+      "tool_slug": "caseodds-ai",
+      "why": "PI-adjacent case outcome prediction can anchor settlement valuations and demand-letter dollar figures when calibrated against firm historical data."
+    },
+    {
+      "tool_slug": "cocounsel-by-thomson-reuters-138",
+      "why": "Broad legal workflow coverage — useful when a PI firm wants one vendor for research, drafting, and document analysis under a single governance framework."
+    },
+    {
+      "tool_slug": "everlaw-464",
+      "why": "Strong fit for medical record review at volume — defensible workflow controls and structured collaboration matter for plaintiff teams processing thousands of pages per matter."
+    },
+    {
+      "tool_slug": "harvey-v3-3",
+      "why": "Enterprise-grade legal workflow platform. Higher price point but consolidates research, drafting, and analysis for firms that want a single AI stack across practice areas."
+    },
+    {
+      "tool_slug": "paralex-1-194",
+      "why": "Paralegal-assistant positioning maps directly to PI workflow pain — intake triage, document organization, and routine drafting where firms are most short-staffed."
+    },
+    {
+      "tool_slug": "spellbook",
+      "why": "Contract and settlement-agreement review — useful for the back-end of PI matters when settlement terms and lien resolution documents need consistent review."
+    }
+  ],
+  "workflow_tool_comparison": [],
+  "downloads": [],
+  "worked_examples": [
+    {
+      "title": "30-day pilot: medical records summarization",
+      "time_box": "30 days, 1 paralegal, 12 matters",
+      "scenario": "A 4-attorney plaintiff PI firm with one full-time paralegal handling 50+ active matters wants to cut medical-record review time per matter from 4 hours to under 90 minutes without losing accuracy.",
+      "inputs": [
+        "12 active matters with closed treatment timelines and complete records (500-2000 pages each).",
+        "One trained paralegal operator and one attorney quality reviewer.",
+        "Written acceptance criteria: 60% time reduction, correction rate under 20%, reviewer agreement above 80%."
+      ],
+      "process": [
+        "Week 1: baseline current time-per-matter on 3 matters using existing manual workflow.",
+        "Week 2-3: run tool on 6 matters; paralegal generates AI summary, attorney reviews against source pages.",
+        "Week 4: run tool on remaining 3 matters with refined prompt template based on week 2-3 corrections.",
+        "Log time, correction count, and reviewer agreement per matter in a single shared spreadsheet."
+      ],
+      "outputs": [
+        "Per-matter time savings table with mean and standard deviation.",
+        "Correction-rate trend across the 9 AI-assisted matters.",
+        "Go/no-go recommendation with named tool, monthly cost, and named operator owner."
+      ],
+      "qa_findings": [
+        "Hallucinated medication dosages in 2 of 9 summaries — required source-citation enforcement in prompt.",
+        "Date errors when records contained handwritten dates — flagged as out-of-scope for AI pass.",
+        "Diagnostic terminology occasionally simplified incorrectly — required medical-terminology preservation rule."
+      ],
+      "adjustments_made": [
+        "Updated prompt to require page-number citation for every clinical fact in summary.",
+        "Added attorney review checkpoint for any medication, dosage, or diagnostic code line.",
+        "Excluded matters with significant handwritten record fractions from AI workflow."
+      ],
+      "key_takeaway": "AI medical-record summarization can deliver 60%+ time savings on typed records but creates new failure modes around dosage and dates. Workflow controls — not vendor selection — determine whether the savings hold up under malpractice scrutiny."
+    }
+  ],
+  "faq": [
+    {
+      "q": "What is the single best AI tool for a small personal injury firm to start with?",
+      "a": "Start with the tool that fixes your most expensive workflow bottleneck. For most solo-to-5-attorney PI firms that is medical record review or intake triage. The exact vendor matters less than picking one workflow and running a 30-day pilot with written success criteria. Firms that pick a 'general legal AI platform' before defining the workflow usually abandon the tool within 90 days."
+    },
+    {
+      "q": "How much should a PI firm budget for AI tooling per attorney per month in 2026?",
+      "a": "Realistic 2026 ranges are $75-$300 per seat per month for workflow-specific tools and $500-$1,500 per seat per month for broad legal AI platforms. Most small PI firms get more value from two narrow tools than one broad one. Budget an additional 8-16 hours of paralegal training time per tool in the first 60 days — this is the cost most firms underestimate."
+    },
+    {
+      "q": "Does using AI to draft demand letters create malpractice risk?",
+      "a": "Unsupervised AI drafting of demand letters does create risk, primarily from hallucinated medical citations, incorrect dates, and fabricated case law. Properly governed AI drafting — where an attorney reviews against source records before sending — reduces drafting time without expanding exposure. The risk is not in using AI. The risk is in skipping the attorney signoff gate that AI makes easier to skip."
+    },
+    {
+      "q": "Can AI replace a paralegal at a PI firm?",
+      "a": "No, and firms that try this lose money. AI compresses paralegal hours per matter, which lets one paralegal handle more cases or lets the firm absorb growth without hiring. Firms that try to replace paralegals with AI typically miss the reality that paralegals do quality control, client communication, and judgment work that current AI cannot defensibly handle in 2026."
+    },
+    {
+      "q": "Which AI tools are PI firms actually adopting in 2026 versus just demoing?",
+      "a": "Adoption clusters around tools that solve one workflow well: medical record summarization, intake triage, demand letter first drafts, and case valuation benchmarking. Broad legal AI platforms get demoed often but show lower sustained adoption past day 90 at small-to-mid PI firms. The pattern across Counterbench's directory: PI firms commit to narrow tools and churn out of broad platforms."
+    },
+    {
+      "q": "What should a PI firm ask a vendor before signing a contract?",
+      "a": "Six questions: (1) Where does our client data go? (2) Is our data used to train models? (3) What is the export format for outputs and prompts? (4) What audit log do you provide for AI-generated work product? (5) What is the rollback path if we cancel? (6) Can we run a 30-day pilot with no annual commitment? If a vendor cannot answer any of these in writing, walk away."
+    },
+    {
+      "q": "How does Counterbench evaluate the tools on this list?",
+      "a": "Counterbench scores tools on workflow fit, auditability, QA burden, adoption effort, governance clarity, and price transparency — not on feature counts or vendor demos. Each tool entry links to a longer evaluation in the directory with notes on what the tool is and is not good for. Listings are independent of vendor relationships, and any sponsored placement is labeled."
+    }
+  ],
+  "citations": [
+    {
+      "title": "Counterbench.AI Directory — Plaintiff Litigation Curation",
+      "url": "https://counterbench.ai/guides/curation-best-legal-ai-tools-for-plaintiff-litigation-teams-2026"
+    },
+    {
+      "title": "Counterbench.AI Paralegal Teams",
+      "url": "https://counterbench.ai/paralegals"
+    },
+    {
+      "title": "Counterbench.AI Tool Directory",
+      "url": "https://counterbench.ai/tools"
+    },
+    {
+      "title": "Counterbench.AI Document Drafting Prompt Library",
+      "url": "https://counterbench.ai/prompts"
+    },
+    {
+      "title": "Counterbench.AI Defensible AI Doc Review Protocol",
+      "url": "https://counterbench.ai/guides/defensible-ai-doc-review-protocol-2026"
+    }
+  ],
+  "recommended_pack_slugs": [],
+  "changelog": [
+    {
+      "date": "2026-05-20",
+      "changes": [
+        "Initial publication of the PI Answer Hub.",
+        "Six ranked tools with PI-specific positioning rationale.",
+        "30-day pilot worked example for medical records summarization.",
+        "Procurement red-flag list and 6-question vendor checklist in FAQ."
+      ]
+    }
+  ],
+  "last_updated": "2026-05-20"
+}

--- a/docs/vapi-setup.md
+++ b/docs/vapi-setup.md
@@ -1,0 +1,196 @@
+# Vapi Setup Guide — CounterbenchAI Receptionist
+
+**Webhook endpoint:** `https://counterbench.ai/api/receptionist/call-complete`
+
+---
+
+## 1. Create a Vapi Account and Get Your API Key
+
+1. Go to [vapi.ai](https://vapi.ai) and sign up.
+2. In the dashboard, navigate to **Settings > API Keys**.
+3. Create a new key and copy it. Store it in Notion under "API and Token Keys."
+4. You will use this key in the Vapi dashboard when configuring the assistant and for any direct API calls.
+
+---
+
+## 2. Buy or Import a Phone Number
+
+Each firm needs its own dedicated Vapi number so the webhook can map inbound calls to the right attorney.
+
+**Option A - Buy a number in Vapi:**
+1. Dashboard > **Phone Numbers > Buy Number**.
+2. Search by area code matching the firm's market (e.g., 617 for Boston).
+3. Purchase and note the full E.164 number (e.g., `+16175550100`).
+
+**Option B - Import a Twilio number:**
+1. Dashboard > **Phone Numbers > Import**.
+2. Provide your Twilio Account SID, Auth Token, and the number. Vapi takes control of it.
+
+---
+
+## 3. Create the Assistant
+
+### 3a. System Prompt
+
+Use this prompt verbatim or adapt per firm. Replace bracketed values.
+
+```
+You are the virtual receptionist for [Firm Name], a personal injury law firm in [City, State]. Your job is to answer calls professionally, make callers feel heard, and collect the information the attorneys need to follow up.
+
+Guidelines:
+- Greet warmly and introduce yourself as the firm's virtual receptionist.
+- Speak clearly and at a measured pace. Do not rush callers.
+- If a caller is distressed, acknowledge their situation briefly before asking questions.
+- Collect the following before ending the call:
+  1. Caller's full name
+  2. Best callback number (confirm if it differs from the number they called from)
+  3. Type of case (car accident, slip and fall, workplace injury, medical malpractice, other)
+  4. Brief description of what happened (2-3 sentences is enough — do not probe for legal details)
+  5. Urgency level: Does the caller need a same-day callback, or is tomorrow acceptable?
+  6. Preferred callback time window if they have one
+- Never give legal advice. If asked, say: "One of our attorneys will be able to speak with you about that directly."
+- End the call by confirming: "I've passed your information to the team. Someone will be in touch [timeframe]. Thank you for calling [Firm Name]."
+```
+
+### 3b. Structured Data Schema
+
+In the assistant config, enable **Analysis > Structured Data** and set this schema. This populates `message.analysis.structuredData` in the webhook payload.
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "callerName": {
+      "type": "string",
+      "description": "Full name of the caller"
+    },
+    "callbackNumber": {
+      "type": "string",
+      "description": "Best phone number to reach the caller"
+    },
+    "caseType": {
+      "type": "string",
+      "enum": ["car_accident", "slip_and_fall", "workplace_injury", "medical_malpractice", "other"],
+      "description": "Type of personal injury case"
+    },
+    "caseDescription": {
+      "type": "string",
+      "description": "Brief description of the incident in the caller's own words"
+    },
+    "urgency": {
+      "type": "string",
+      "enum": ["same_day", "next_day", "flexible"],
+      "description": "How urgently the caller needs a callback"
+    },
+    "preferredCallbackTime": {
+      "type": "string",
+      "description": "Caller's preferred callback time window, if stated"
+    }
+  },
+  "required": ["callerName", "caseType", "urgency"]
+}
+```
+
+### 3c. End-of-Call Webhook
+
+In the assistant config under **Server > Messages**, add:
+
+- **Server URL:** `https://counterbench.ai/api/receptionist/call-complete`
+- **Server Messages:** `["end-of-call-report"]`
+
+This triggers the webhook exactly once at the end of each call with the full payload including transcript and structured data.
+
+### 3d. Voice and Model Settings (Recommended)
+
+- **Voice:** ElevenLabs "Rachel" or Vapi's built-in "Paige" - warm, professional female voice.
+- **Model:** GPT-4o (best accuracy for intake; latency is acceptable for receptionist use cases).
+- **Max duration:** 600 seconds (10 minutes). Adjust if needed.
+- **Background sound:** Off. Legal callers expect clean audio.
+
+---
+
+## 4. Link the Phone Number to the Assistant
+
+1. Dashboard > **Phone Numbers > [Your Number]**.
+2. Under **Inbound**, set **Assistant** to the assistant you just created.
+3. Save. All inbound calls to that number now route to the assistant.
+
+---
+
+## 5. Add the Firm to the Database
+
+The webhook looks up the firm by matching `message.call.phoneNumber.number` against the `phone_number` column in `receptionist_firms`. Use the admin endpoint to add the firm — preferred over raw SQL.
+
+**Prereq:** Set `ADMIN_API_KEY` in Vercel env (generate with `openssl rand -hex 32`).
+
+```fish
+set -x ADMIN_API_KEY <your-admin-key>
+curl -X POST https://counterbench.ai/api/admin/receptionist/firms \
+  -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Smith & Associates Personal Injury",
+    "phoneNumber": "+16175550100",
+    "attorneyEmail": "attorney@smithpifirm.com",
+    "attorneyPhone": "+15614064984",
+    "caseTypes": "auto accident, slip and fall",
+    "callbackTime": "30 minutes"
+  }'
+```
+
+**Critical:** The `phoneNumber` value must be the exact E.164 string Vapi sends in `message.call.phoneNumber.number`. Verify in the Vapi dashboard — it will include the country code and no spaces or dashes.
+
+If the number does not match, the call is still logged to `receptionist_calls` with `firmId = 'unknown'` but no intake email is sent.
+
+### Other admin operations
+
+```fish
+# List all firms
+curl -H "x-admin-key: $ADMIN_API_KEY" https://counterbench.ai/api/admin/receptionist/firms
+
+# Update a firm
+curl -X PATCH https://counterbench.ai/api/admin/receptionist/firms/<id> \
+  -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"caseTypes": "auto accident, slip and fall, premises liability"}'
+
+# Deactivate (soft) — set active="false"
+curl -X PATCH https://counterbench.ai/api/admin/receptionist/firms/<id> \
+  -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{"active": "false"}'
+
+# Delete (hard)
+curl -X DELETE https://counterbench.ai/api/admin/receptionist/firms/<id> \
+  -H "x-admin-key: $ADMIN_API_KEY"
+```
+
+---
+
+## 6. Test Call Checklist
+
+Run through this after setup before going live with a firm.
+
+- [ ] Call the Vapi number from a real mobile phone.
+- [ ] Confirm the assistant answers and the greeting matches the system prompt.
+- [ ] Provide test intake data: name, case type, callback preference.
+- [ ] End the call naturally ("That's all, thank you").
+- [ ] Within 30 seconds, check the attorney email inbox for the intake summary.
+- [ ] Confirm the email contains: caller number, called number, duration, transcript, and structured data block.
+- [ ] Check the `receptionist_calls` table to confirm the row was inserted with the correct `firmId`.
+- [ ] If no email arrives: check that `phone_number` in `receptionist_firms` matches exactly. Check Vercel function logs for `receptionist_firm_not_found` or `receptionist_webhook_error` events.
+
+---
+
+## Payload Reference
+
+The handler extracts these fields from the Vapi `end-of-call-report` payload:
+
+| Field | Vapi Path | Fallback |
+|---|---|---|
+| Call ID | `message.call.id` | `"unknown"` |
+| Caller number | `message.call.customer.number` | `message.call.customerPhoneNumber` |
+| Called number (firm lookup) | `message.call.phoneNumber.number` | `message.call.to` |
+| Transcript | `message.artifact.transcript` | `message.transcript` |
+| Structured data | `message.analysis.structuredData` | none |
+| Duration (seconds) | `message.durationSeconds` | `0` |

--- a/public/.well-known/brand-facts.json
+++ b/public/.well-known/brand-facts.json
@@ -1,15 +1,54 @@
 {
   "name": "Counterbench.AI",
   "website": "https://counterbench.ai",
-  "summary": "A curated directory of legal AI tools plus prompt templates and playbooks for legal teams.",
-  "audience": ["Paralegals", "Law firms", "Solo lawyers", "Legal researchers", "Legal ops"],
+  "category": "Legal AI tooling directory and paralegal services for US personal injury law firms",
+  "summary": "A curated directory of legal AI tools plus prompt templates, playbooks, and managed paralegal teams designed for plaintiff and personal injury practices.",
+  "audience": ["Personal injury law firms", "Plaintiff-side litigation teams", "Paralegals", "Solo lawyers", "Legal researchers", "Legal operations leads"],
+  "offerings": [
+    {
+      "type": "directory",
+      "name": "Legal AI Tool Directory",
+      "url": "https://counterbench.ai/tools",
+      "pricing": "free"
+    },
+    {
+      "type": "service",
+      "name": "Paralegal Teams (managed)",
+      "url": "https://counterbench.ai/paralegals",
+      "pricingRange": "$3,750-$6,500 per month",
+      "engagementModel": "monthly retainer"
+    },
+    {
+      "type": "content",
+      "name": "Prompt Library and Playbooks",
+      "url": "https://counterbench.ai/prompts"
+    }
+  ],
+  "specialization": "Personal injury and plaintiff-side legal practice",
+  "differentiators": [
+    "Independent tool evaluations scored against workflow fit, auditability, and reviewer agreement — not feature checklists.",
+    "Combines an AI tool directory with a managed human paralegal layer so firms do not have to pick between software and staff.",
+    "Plaintiff-focused — most directory entries and playbooks are sized for solo-to-mid PI practices, not BigLaw."
+  ],
   "keyPages": {
     "tools": "https://counterbench.ai/tools",
     "guides": "https://counterbench.ai/guides",
     "prompts": "https://counterbench.ai/prompts",
     "playbooks": "https://counterbench.ai/playbooks",
-    "resources": "https://counterbench.ai/resources"
+    "resources": "https://counterbench.ai/resources",
+    "paralegals": "https://counterbench.ai/paralegals",
+    "piAnswerHub": "https://counterbench.ai/guides/best-ai-tools-pi-law-firms-2026"
   },
+  "anchorGuides": [
+    {
+      "title": "Best AI Tools for Personal Injury Law Firms (2026)",
+      "url": "https://counterbench.ai/guides/best-ai-tools-pi-law-firms-2026"
+    },
+    {
+      "title": "Best Legal AI Tools for Plaintiff Litigation Teams (2026)",
+      "url": "https://counterbench.ai/guides/curation-best-legal-ai-tools-for-plaintiff-litigation-teams-2026"
+    }
+  ],
   "discovery": {
     "sitemap": "https://counterbench.ai/sitemap.xml",
     "searchIndex": "https://counterbench.ai/search-index.json",
@@ -21,9 +60,14 @@
     "terms": "https://counterbench.ai/terms",
     "eula": "https://counterbench.ai/eula"
   },
+  "compliance": [
+    "Vendor reviews note data retention and training-use policies where vendors publish them.",
+    "Paralegal Teams service operates under written engagement letters; HIPAA BAAs available on request."
+  ],
   "notes": [
     "Counterbench.AI provides educational information and a directory of third-party tools; it does not provide legal advice.",
-    "Listings may include a 'Verified' badge and a 'Last checked' date where available."
+    "Listings may include a 'Verified' badge and a 'Last checked' date where available.",
+    "VerdictOps merged into Counterbench.AI in April 2026; verdictops.com redirects to /paralegals."
   ],
-  "lastUpdated": "2026-03-09"
+  "lastUpdated": "2026-05-20"
 }

--- a/scripts/receptionist-launch.fish
+++ b/scripts/receptionist-launch.fish
@@ -1,0 +1,164 @@
+#!/usr/bin/env fish
+# Remote Receptionist V1 — Phil's 90-min sitting
+# Run interactively. Each step pauses for confirmation.
+#
+# Usage:
+#   chmod +x scripts/receptionist-launch.fish
+#   ./scripts/receptionist-launch.fish
+#
+# Prereqs:
+#   - On feat/sales-motion-lock branch (merged or current)
+#   - Logged into Vercel CLI (`vercel login`)
+#   - Neon prod DATABASE_URL ready to paste
+#   - Resend API key ready to paste
+
+set -l PROJECT_DIR (dirname (status -f))/..
+cd $PROJECT_DIR
+
+function pause_for
+    echo
+    echo "--- $argv[1] ---"
+    read -P "Press Enter when done, or Ctrl-C to abort: "
+end
+
+function confirm_continue
+    read -P "Continue? [y/N]: " ans
+    if test "$ans" != "y" -a "$ans" != "Y"
+        echo "Aborted."
+        exit 1
+    end
+end
+
+# ---------------------------------------------------------------
+# STEP 1 — Load ADMIN_API_KEY
+# ---------------------------------------------------------------
+echo "STEP 1: Load ADMIN_API_KEY from .env.local.scratch"
+if test -f .env.local.scratch
+    set -x ADMIN_API_KEY (grep ADMIN_API_KEY .env.local.scratch | cut -d= -f2)
+    echo "Loaded: ADMIN_API_KEY=$ADMIN_API_KEY"
+else
+    echo "No .env.local.scratch found. Generating new key:"
+    set -x ADMIN_API_KEY (openssl rand -hex 32)
+    echo "ADMIN_API_KEY=$ADMIN_API_KEY"
+end
+confirm_continue
+
+# ---------------------------------------------------------------
+# STEP 2 — Set Vercel env vars
+# ---------------------------------------------------------------
+echo
+echo "STEP 2: Vercel env vars (Production scope)"
+echo
+echo "Paste these into Vercel → Project Settings → Environment Variables:"
+echo
+echo "  DATABASE_URL        <Neon prod connection string with sslmode=require>"
+echo "  RESEND_API_KEY      <from resend.com/api-keys>"
+echo "  RESEND_FROM         noreply@counterbench.ai"
+echo "  ADMIN_API_KEY       $ADMIN_API_KEY"
+echo "  ATTORNEY_SMS_EMAIL  <optional: 5551234567@vtext.verizon.net>"
+echo
+echo "Or use CLI (one at a time):"
+echo "  vercel env add DATABASE_URL production"
+echo "  vercel env add RESEND_API_KEY production"
+echo "  vercel env add RESEND_FROM production"
+echo "  vercel env add ADMIN_API_KEY production"
+echo
+pause_for "Done setting Vercel env vars"
+
+# ---------------------------------------------------------------
+# STEP 3 — Push Drizzle schema to Neon
+# ---------------------------------------------------------------
+echo
+echo "STEP 3: Push schema to Neon"
+echo "Paste the DATABASE_URL below (will export to this shell only)"
+read -P "DATABASE_URL: " -s neon_url
+echo
+set -x DATABASE_URL $neon_url
+echo "Running: npx drizzle-kit push"
+npx drizzle-kit push
+or begin
+    echo "drizzle-kit push failed. Fix and rerun."
+    exit 1
+end
+confirm_continue
+
+# ---------------------------------------------------------------
+# STEP 4 — Vapi assistant setup (manual)
+# ---------------------------------------------------------------
+echo
+echo "STEP 4: Vapi assistant"
+echo
+echo "Open: https://dashboard.vapi.ai"
+echo "Follow: docs/vapi-setup.md (sections 1-4)"
+echo
+echo "Key settings:"
+echo "  - Webhook URL: https://counterbench.ai/api/receptionist/call-complete"
+echo "  - Webhook events: end-of-call-report"
+echo "  - Buy or import phone number, link to assistant"
+echo
+echo "Capture the assistant phone number (E.164 format, e.g. +16175550100)"
+read -P "Vapi assistant phone number: " VAPI_PHONE
+
+# ---------------------------------------------------------------
+# STEP 5 — Trigger a Vercel deploy so env vars + new routes go live
+# ---------------------------------------------------------------
+echo
+echo "STEP 5: Deploy to Vercel"
+echo "Push branch if not already:"
+echo "  git push origin feat/sales-motion-lock"
+echo "Then open the PR + merge to main, OR run:"
+echo "  vercel --prod"
+pause_for "Production deploy complete (counterbench.ai live with new routes)"
+
+# ---------------------------------------------------------------
+# STEP 6 — Seed first firm
+# ---------------------------------------------------------------
+echo
+echo "STEP 6: Seed first firm via admin endpoint"
+read -P "Firm name: " FIRM_NAME
+read -P "Attorney email (for intake alerts): " ATTORNEY_EMAIL
+read -P "Attorney phone E.164 (e.g. +15614064984): " ATTORNEY_PHONE
+read -P "Case types (comma-separated): " CASE_TYPES
+
+curl -sS -X POST https://counterbench.ai/api/admin/receptionist/firms \
+  -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "content-type: application/json" \
+  -d "{
+    \"name\": \"$FIRM_NAME\",
+    \"phoneNumber\": \"$VAPI_PHONE\",
+    \"attorneyEmail\": \"$ATTORNEY_EMAIL\",
+    \"attorneyPhone\": \"$ATTORNEY_PHONE\",
+    \"caseTypes\": \"$CASE_TYPES\",
+    \"callbackTime\": \"30 minutes\"
+  }" | jq .
+
+confirm_continue
+
+# ---------------------------------------------------------------
+# STEP 7 — E2E test call
+# ---------------------------------------------------------------
+echo
+echo "STEP 7: End-to-end test"
+echo
+echo "Place a call to: $VAPI_PHONE"
+echo "Expected:"
+echo "  - Vapi assistant answers + screens"
+echo "  - Email arrives at $ATTORNEY_EMAIL with transcript"
+echo "  - If ATTORNEY_SMS_EMAIL set, SMS-via-email arrives"
+echo
+pause_for "Made test call"
+
+echo
+echo "Verify call logged:"
+curl -sS https://counterbench.ai/api/receptionist/calls | jq '.calls[0]'
+echo
+
+echo "================================================="
+echo "  Remote Receptionist V1 LIVE"
+echo "================================================="
+echo
+echo "Cleanup:"
+echo "  rm .env.local.scratch    # delete temporary key file"
+echo
+echo "Next: pitch to 3 PI firms (\$349/mo, 14-day pilot)"
+echo "  Use tasks/sales-motion-lock-next-5.md outreach list"

--- a/tasks/decisions.md
+++ b/tasks/decisions.md
@@ -1,5 +1,20 @@
 # Decisions Log
 
+## 2026-05-21: Sales motion locked + Remote Receptionist admin endpoints landed
+
+**Decision**: Lock CB paralegal-teams sales motion (ICP, offer, channel mix, cadence) until 2026-08-01 review. No edits to motion mid-quarter — only data updates. Ship `/api/admin/receptionist/firms` CRUD behind `x-admin-key` so firms can be seeded without raw SQL.
+
+**Rationale**: Strategic Self-Audit (May 2026) named CounterbenchAI top portfolio priority and flagged "no repeatable sales motion" as bottleneck. VerdictOps brand sunset (2026-04-22) — verdictops.com 301s to counterbench.ai/paralegals; all receptionist work is CB-only now. Admin endpoint replaces the raw-SQL seeding step in `docs/vapi-setup.md` so launch is repeatable per firm.
+
+**Implication**:
+- Branch `feat/sales-motion-lock` ready for PR (4 commits: sales motion lock, admin CRUD, NextJS 15 async params fix)
+- Phil's 90-min sitting captured in `tasks/remote-receptionist-launch-checklist.md` and `scripts/receptionist-launch.fish`
+- Kill criteria tripwire D added: Receptionist V1 not E2E-tested by 2026-06-15
+- VerdictOps Express/EJS receptionist endpoint is dead code (live URL 301-redirects); no longer maintained
+- ADMIN_API_KEY for prod was generated 2026-05-21 and stored in `.env.local.scratch` (gitignored via `*.scratch`)
+
+---
+
 ## 2026-03-29: Stripe checkout custom_fields use semantic value names
 
 **Decision**: Stripe dropdown `value` fields must be alphanumeric-only. Used semantic names: `small`/`midsize`/`large`/`enterprise` for firm_size, `officemanager` for office manager role.

--- a/tasks/remote-receptionist-launch-checklist.md
+++ b/tasks/remote-receptionist-launch-checklist.md
@@ -1,0 +1,106 @@
+# Remote Receptionist — Launch Checklist (CounterbenchAI)
+
+Last updated: 2026-05-21
+Branch: `feat/sales-motion-lock`
+Domain: counterbench.ai
+
+## Status snapshot
+
+| Component | State |
+|-----------|-------|
+| `/api/receptionist/call-complete` (Vapi end-of-call webhook) | Built |
+| `/api/receptionist/calls` (call log read) | Built |
+| `/api/admin/receptionist/firms[/:id]` (CRUD) | **Built this branch** |
+| Drizzle schema (`receptionist_firms` + `receptionist_calls`) | Defined in `lib/db/schema.ts` |
+| Resend email + SMS-gateway alerting | Wired |
+| Service page + paralegal landing | Live at counterbench.ai/paralegals |
+| `docs/vapi-setup.md` | Live |
+| **DB migration pushed (prod Neon)** | **PENDING** (Phil action) |
+| **Vercel env vars set** | **PENDING** (Phil action) |
+| **Vapi assistant configured** | **PENDING** (Phil action) |
+| **First firm seeded via admin endpoint** | **PENDING** (Phil action) |
+| **End-to-end test call** | **PENDING** (Phil action) |
+
+## What was built this branch
+
+`app/api/admin/receptionist/firms/route.ts` — `GET` (list), `POST` (create)
+`app/api/admin/receptionist/firms/[id]/route.ts` — `PATCH` (update), `DELETE` (remove)
+
+Both routes require `x-admin-key` header matching `ADMIN_API_KEY`. Use Zod for body validation. Both export `dynamic = "force-dynamic"` + `runtime = "nodejs"`.
+
+`.env.example` — documented `ADMIN_API_KEY`, `ATTORNEY_SMS_EMAIL`.
+
+## Phil action items (90-min sitting)
+
+### 1. Generate admin key
+```fish
+openssl rand -hex 32
+```
+Copy output.
+
+### 2. Set Vercel env vars (Production scope on counterbench.ai project)
+Required:
+- `DATABASE_URL` — Neon prod connection string (sslmode=require)
+- `RESEND_API_KEY` — from resend.com/api-keys
+- `RESEND_FROM` — `noreply@counterbench.ai`
+- `ADMIN_API_KEY` — value from step 1
+
+Optional:
+- `ATTORNEY_SMS_EMAIL` — carrier email-to-SMS gateway (e.g. `5551234567@vtext.verizon.net`)
+
+### 3. Push schema
+```fish
+cd ~/Downloads/Projects/CounterbenchAI
+set -x DATABASE_URL "<paste-prod-neon-url>"
+npx drizzle-kit push
+```
+Creates `receptionist_firms` + `receptionist_calls` tables.
+
+### 4. Configure Vapi assistant
+Follow `docs/vapi-setup.md`. Key items:
+- Webhook URL: `https://counterbench.ai/api/receptionist/call-complete`
+- Webhook events: `end-of-call-report`
+- Assign Vapi-provisioned phone number to firm in next step
+
+### 5. Seed first firm via admin endpoint
+Replace SQL step in `docs/vapi-setup.md` with this curl:
+```fish
+curl -X POST https://counterbench.ai/api/admin/receptionist/firms \
+  -H "x-admin-key: $ADMIN_API_KEY" \
+  -H "content-type: application/json" \
+  -d '{
+    "name": "Smith & Associates PI",
+    "phoneNumber": "+16175550100",
+    "attorneyEmail": "phil@counterbench.ai",
+    "attorneyPhone": "+15614064984",
+    "caseTypes": "auto accident, slip and fall",
+    "callbackTime": "30 minutes"
+  }'
+```
+`phoneNumber` MUST match the Vapi assistant's E.164 number exactly.
+
+### 6. End-to-end test
+- Call the Vapi number
+- Confirm intake flow
+- Verify:
+  - Email arrives at `attorneyEmail`
+  - SMS arrives at `ATTORNEY_SMS_EMAIL` (if set)
+  - Call appears at `GET https://counterbench.ai/api/receptionist/calls`
+
+### 7. First paying firm
+- Once test passes, pitch to 3 PI firms from `tasks/PI_FIRMS.xlsx` + `Counterbench Targets/`
+- Offer: $349/month, 14-day pilot, no setup fee
+- On signup: re-run step 5 with their data
+
+## Legacy note (VerdictOps)
+
+VerdictOps brand sunset (commit `97709d0` in legacy repo, verdictops.com 301s to counterbench.ai/paralegals). All receptionist code lives in CounterbenchAI repo. The legacy Express/EJS receptionist endpoint in `~/Downloads/Projects/VerdictOps/server/index.ts` (commit `c7ba3b8`) is dead code; it is **not** receiving traffic since the domain redirects. Safe to ignore.
+
+## Out of scope (V1)
+
+- Web admin UI (curl/HTTPie for now)
+- Per-firm dashboard
+- Call recording playback
+- CRM push (Lawmatics/Litify integration)
+- Multi-language support
+- Stripe billing integration for self-serve signup

--- a/tasks/sales-motion-lock-next-5.md
+++ b/tasks/sales-motion-lock-next-5.md
@@ -158,7 +158,7 @@ Target conversion: 100 signals → 30 contacted → 10 engaged → 5 calls → 3
 ## First actions (this week)
 
 - [ ] Create `tasks/pipeline.csv` with 10 firms from PI_FIRMS.xlsx + their paralegal job postings
-- [ ] Confirm Calendly link working (use VerdictOps fix from commit 2827e99)
+- [ ] Confirm Calendly link working on counterbench.ai/paralegals
 - [ ] Email all current clients re: referral offer (1 month free for annual referral)
 - [ ] Send first batch of 20 day-0 emails Tuesday 2026-05-26
 - [ ] Schedule Monday pipeline review block 9-10:30am
@@ -168,7 +168,8 @@ Target conversion: 100 signals → 30 contacted → 10 engaged → 5 calls → 3
 
 - Strategic Self-Audit: `~/Downloads/Strategic-Self-Audit-Phil-Rimmler-May2026.docx`
 - Kill criteria: `~/Downloads/Projects/_ops/03-kill-criteria.md`
-- EBT pipeline (pitchable asset): VerdictOps `tasks/remote-receptionist-v1-scope.md` + EBT outline generator
+- Remote Receptionist launch: `tasks/remote-receptionist-launch-checklist.md` (pitchable asset)
+- EBT outline pipeline: pitchable asset, built, not yet productized
 - Existing cold email batch: `tasks/cold-email-batch-1/`
 - Reddit playbook: `tasks/reddit-outbound-playbook.md`
 - ICP brand model: `tasks/brand-narrative-enemy-model.md`

--- a/tasks/sales-motion-lock-next-5.md
+++ b/tasks/sales-motion-lock-next-5.md
@@ -1,0 +1,174 @@
+# CounterbenchAI — Sales Motion Lock: Next 5 Paralegal Team Clients
+
+Created: 2026-05-21
+Owner: Phil Rimmler
+Goal: Close 5 net-new paralegal team retainer clients by **2026-08-01**
+Tripwire (kill criteria): < 8 paying retainer clients by 2026-09-01
+
+## Why this doc
+
+Strategic Self-Audit (May 2026) named CounterbenchAI the highest-probability winner in the portfolio (active clients, recurring revenue, hard-to-copy position) and identified the bottleneck as "no repeatable sales motion." This locks the motion.
+
+Everything in this doc is the system. No edits to the motion mid-quarter — only data updates.
+
+## ICP (locked)
+
+**Firm shape**
+- PI law firms, solo to 10-attorney
+- Paralegal-understaffed (1 paralegal per 3+ attorneys, OR no dedicated paralegal)
+- Volume: 30+ open cases at any time
+- Geography: US, English-speaking, no jurisdiction restrictions
+- Pain present: discovery deadlines slipping, medical chronology backlog, intake overflow
+
+**Decision-maker**
+- Managing partner or firm owner (NOT operations manager — too low in chain)
+- 5+ years in practice (younger firms haven't felt the pain yet)
+
+**Disqualifiers (skip immediately)**
+- > 10 attorneys (different sales cycle, need enterprise motion)
+- Insurance defense (different economics, lower fees, weak fit)
+- Already using LegalEase/Abogados/offshore — wait 90 days post-cancellation
+- Firms with full-time in-house paralegal pool > 5 people
+
+## Offer (locked)
+
+**Core retainer:** Paralegal Teams
+- Starter — $3,750/mo — 1 dedicated paralegal, ~80 hours/mo
+- Standard — $4,950/mo — 1 paralegal + AI tool access (EBT pipeline, intake)
+- Pro — $6,500/mo — 2 paralegals + AI tools + dedicated case manager
+
+**Pilot offer (for first 5 clients in this sprint)**
+- 30-day pilot at $2,500 fixed
+- No setup fee
+- Money back if not satisfied at day 14
+- Auto-converts to chosen tier at day 31 unless cancelled
+
+**Why pilot:** Reduces close friction. Self-Audit flagged "first-customer avoidance" — the pilot is structurally easier to say yes to.
+
+## Channel mix (locked — 70/20/10)
+
+### 70% — Direct outbound (highest signal, slowest cycle)
+
+**Source list:** `~/Downloads/Projects/CounterbenchAI/tasks/PI_FIRMS.xlsx` + `Counterbench Targets/`
+
+**Signal trigger:** Paralegal job posting on Indeed/LinkedIn in last 30 days
+- Means: actively understaffed, budget approved, problem named
+- Volume target: 20 signals/week, 100/month
+
+**Cadence per target (12 days, 6 touches):**
+- Day 0: Email — case-study-led, no ask, 3 sentences
+- Day 2: LinkedIn connection request (no message)
+- Day 5: Email — specific cost comparison ($65k+ FTE vs $3,750/mo retainer)
+- Day 7: LinkedIn DM if connected
+- Day 10: Email — pilot offer, money-back, calendar link
+- Day 12: Phone call (warm or cold) OR drop
+
+**Email templates:** `~/Downloads/Projects/CounterbenchAI/tasks/cold-email-batch-1/`
+
+### 20% — Reddit / community pull
+
+**Subs:** r/legaltech, r/paralegal, r/LawFirm, r/Lawyertalk
+**Cadence:** 3 substantive comments/week + 1 long-form post/month
+**Goal:** Inbound leads to https://counterbench.ai/paralegals
+**Playbook:** `~/Downloads/Projects/CounterbenchAI/tasks/reddit-outbound-playbook.md`
+
+### 10% — Referrals
+
+**Source:** existing CB clients + Petrichor portfolio
+**Offer:** 1 month of buyer's retainer free for referrer if referral signs annual
+**Action:** Email all current clients once on day 7 of this sprint
+
+## Weekly cadence (locked)
+
+### Monday — Pipeline review (90 min)
+- Pull this week's signals (paralegal job postings)
+- Score 20 firms, drop 0–10 into outreach queue
+- Review Reddit weekly KPIs: comments, replies, profile views
+- Update `tasks/pipeline.csv` (create if missing)
+
+### Tuesday — Outbound batch (2 hrs)
+- Send 20 personalized day-0 emails
+- Send 20 day-5 follow-ups
+- Make 5 phone calls from day-12 list
+
+### Wednesday — Inbound + meetings
+- Take discovery calls (Calendly default)
+- Process inbound from blog/Reddit/LinkedIn
+
+### Thursday — Content + Reddit
+- Write 1 blog post for counterbench.ai (rotate: case study, ICP pain, comparison)
+- 5 Reddit comments
+- 5 LinkedIn comments on prospect posts
+
+### Friday — Close + retro
+- Pilot proposals out
+- Update pipeline.csv with stage changes
+- Weekly retro: what worked, what to drop
+- One sentence to memory: this week's biggest lesson
+
+## Pipeline stages (locked)
+
+1. **Signal** — paralegal job post detected
+2. **Researched** — firm sized, partner identified, case types confirmed
+3. **Contacted** — day-0 email sent
+4. **Engaged** — replied / opened multiple times / connected on LinkedIn
+5. **Call booked** — discovery call on calendar
+6. **Call held** — discovery complete, qualified
+7. **Pilot proposed** — written proposal sent
+8. **Pilot signed** — first invoice paid
+9. **Converted** — month 2 invoice paid (counts toward "5 clients")
+10. **Lost** — explicit no OR 30 days no response post-day-12
+
+Target conversion: 100 signals → 30 contacted → 10 engaged → 5 calls → 3 pilots → 2 conversions per month. Hit 2 conversions × 2.5 months = 5 clients by 2026-08-01.
+
+## KPIs (locked — review every Monday)
+
+| Metric | Weekly target | Track in |
+|--------|--------------|----------|
+| Signals identified | 20 | pipeline.csv |
+| Day-0 emails sent | 20 | pipeline.csv |
+| Reply rate | > 8% | pipeline.csv |
+| Calls booked | 2 | Calendly + pipeline.csv |
+| Pilots proposed | 1 | pipeline.csv |
+| Pilots signed | 0.5 (1 every 2 weeks) | pipeline.csv |
+| MRR added | $2,500 | invoicing |
+
+**Red flag:** any KPI < 50% of target for 2 consecutive weeks → emergency motion review.
+
+## What this motion explicitly does NOT do
+
+(Anti-scope creep — Self-Audit flagged "pre-revenue infrastructure bias")
+
+- No new landing pages until 3 pilots signed
+- No new content categories until existing posts have 90 days of data
+- No paid ads until cold outbound proves 8% reply rate
+- No SEO investment beyond existing posts
+- No new tool building (EBT pipeline pitches use existing build)
+- No new ICP segments (insurance defense, mid-market, etc.) until 5 PI clients converted
+- No new pricing tiers
+- No partnership outreach (legal staffing agencies, etc.) until 5 clients
+
+## Stop conditions (when to revisit this doc)
+
+1. **5 clients closed before 2026-08-01** → revisit to scale motion (hire 2nd closer, add 2nd ICP)
+2. **0 pilots closed by 2026-07-01** → emergency review: ICP wrong, offer wrong, or channel wrong?
+3. **Reply rate < 4% for 4 weeks** → email copy is the bottleneck, rebuild from templates
+4. **Pilot → conversion rate < 50%** → product/service quality issue, NOT sales issue, fix delivery
+
+## First actions (this week)
+
+- [ ] Create `tasks/pipeline.csv` with 10 firms from PI_FIRMS.xlsx + their paralegal job postings
+- [ ] Confirm Calendly link working (use VerdictOps fix from commit 2827e99)
+- [ ] Email all current clients re: referral offer (1 month free for annual referral)
+- [ ] Send first batch of 20 day-0 emails Tuesday 2026-05-26
+- [ ] Schedule Monday pipeline review block 9-10:30am
+- [ ] Add to `tasks/decisions.md`: "Sales motion locked 2026-05-21, no edits to motion until 2026-08-01 review"
+
+## Reference
+
+- Strategic Self-Audit: `~/Downloads/Strategic-Self-Audit-Phil-Rimmler-May2026.docx`
+- Kill criteria: `~/Downloads/Projects/_ops/03-kill-criteria.md`
+- EBT pipeline (pitchable asset): VerdictOps `tasks/remote-receptionist-v1-scope.md` + EBT outline generator
+- Existing cold email batch: `tasks/cold-email-batch-1/`
+- Reddit playbook: `tasks/reddit-outbound-playbook.md`
+- ICP brand model: `tasks/brand-narrative-enemy-model.md`


### PR DESCRIPTION
## Summary

Three connected changes from 2026-05-21 strategic self-audit follow-up:

1. **Sales motion lock** (`tasks/sales-motion-lock-next-5.md`) — locks ICP, offer, channel mix (70/20/10), weekly cadence, KPIs, and stop conditions through 2026-08-01. Goal: 5 net-new paralegal team retainer clients.

2. **Remote Receptionist admin CRUD** — Next.js routes at `/api/admin/receptionist/firms[/:id]` behind `x-admin-key` header auth. Zod-validated. Replaces raw-SQL seeding step in `docs/vapi-setup.md`.

3. **Launch script + decisions log** — `scripts/receptionist-launch.fish` walks Phil through the 90-min sitting (Vercel env, drizzle push, Vapi setup, seed firm, E2E test).

## Files

- `app/api/admin/receptionist/firms/route.ts` — GET, POST
- `app/api/admin/receptionist/firms/[id]/route.ts` — PATCH, DELETE (Next.js 15 async params)
- `.env.example` — adds `ADMIN_API_KEY`, `ATTORNEY_SMS_EMAIL`
- `.gitignore` — adds `*.scratch`, explicit `.env.local`
- `docs/vapi-setup.md` — replaces SQL with curl admin flow
- `tasks/sales-motion-lock-next-5.md` — sales motion locked
- `tasks/remote-receptionist-launch-checklist.md` — Phil's checklist
- `tasks/decisions.md` — entry for this lock
- `scripts/receptionist-launch.fish` — interactive launch walkthrough

## Verification

- `npm run typecheck` — passes
- `npm run build` — passes (admin routes register as dynamic ƒ)
- `npm run lint` — pre-existing errors only, none in new files

## Test plan

- [ ] Merge to main
- [ ] Phil sets Vercel env vars (`DATABASE_URL`, `RESEND_API_KEY`, `RESEND_FROM`, `ADMIN_API_KEY`)
- [ ] `npx drizzle-kit push` against prod Neon
- [ ] Configure Vapi assistant per `docs/vapi-setup.md`
- [ ] Run `scripts/receptionist-launch.fish` for guided seeding + E2E call
- [ ] First firm receives intake email
- [ ] `/api/receptionist/calls` shows logged call

## Context

VerdictOps brand sunset (2026-04-22) — verdictops.com 301s to counterbench.ai/paralegals. The legacy Express/EJS receptionist endpoint in the VerdictOps repo is dead code. All receptionist work is CounterbenchAI-only.