### PR TITLE
fix(e2e): stop suite from silently testing whatever squats the port

### DIFF
--- a/adr/legal-pi-review.md
+++ b/adr/legal-pi-review.md
@@ -1,0 +1,16 @@
+# ADR: legal-pi-review skill
+
+## Decision
+Create a `legal-pi-review` skill specializing `legal-review` for personal injury law firm documents.
+
+## Rationale
+CounterbenchAI targets PI law firms. The generic `legal-review` lacks PI domain knowledge: lien priority, contingency fee caps, Medicare/Medicaid Secondary Payer Act compliance, state bar fee-sharing rules, HIPAA PHI handling in vendor agreements.
+
+## Scope
+- Invoked via `/legal-pi-review <file>`
+- Reuses 5 existing subagents with PI-specific prompts
+- PI-weighted score penalties
+- Output: `PI-CONTRACT-REVIEW-[docname]-[date].md`
+
+## Status
+Accepted

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,18 +1,24 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.E2E_BASE_URL || "http://127.0.0.1:3000";
+// Default port is 3100, not 3000: reuseExistingServer=true means anything already
+// listening on the port (Grafana runs on 3000 on this machine) silently becomes the
+// system under test and the whole suite fails against the wrong app.
+const port = process.env.E2E_PORT || "3100";
+const baseURL = process.env.E2E_BASE_URL || `http://127.0.0.1:${port}`;
 const isRemote = Boolean(process.env.E2E_SKIP_WEBSERVER) || Boolean(process.env.E2E_BASE_URL);
 // Default to prod build + next start so behavior matches Vercel and avoids dev overlays.
 const webServerMode = (process.env.E2E_WEBSERVER_MODE || "prod").toLowerCase();
 const webServerCommand =
   webServerMode === "prod"
     // Build is handled by the npm script (or a previous run); keep the webServer command as start-only.
-    ? "npx next start -H 127.0.0.1 -p 3000"
-    : "npm run dev -- -H 127.0.0.1 -p 3000";
+    ? `npx next start -H 127.0.0.1 -p ${port}`
+    : `npm run dev -- -H 127.0.0.1 -p ${port}`;
 const webServerTimeout = webServerMode === "prod" ? 600_000 : 120_000;
 
 export default defineConfig({
   testDir: "tests/e2e",
+  // Asserts the server at baseURL is actually this app before any test runs.
+  globalSetup: "./tests/e2e/global-setup.ts",
   // In constrained environments (like sandboxes), writing into the repo can be blocked.
   // Use a temp output directory by default.
   outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR || "/tmp/counterbench-playwright",
@@ -37,7 +43,9 @@ export default defineConfig({
     : {
         command: webServerCommand,
         url: baseURL,
-        reuseExistingServer: true,
+        // Reuse locally for fast iteration, but never in CI: a squatted port there
+        // must fail loud instead of silently testing whatever process holds it.
+        reuseExistingServer: !process.env.CI,
         timeout: webServerTimeout
       }
 });

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,11 +19,11 @@
 - [ ] Run drizzle-kit push to create DB tables in production (schema is in `lib/db/schema.ts`)
 - [ ] End-to-end test: full call flow (Vapi webhook → DB → email alert via `app/api/receptionist/call-complete/route.ts`)
 - [ ] Ungate Remote Receptionist page (page exists at `app/(marketing)/paralegals/page.tsx` — confirm it is linked from nav and sitemap)
-- [ ] Verify verdictops.com 301 -> counterbench.ai/paralegals is live (configured at the verdictops.com host/DNS level — NOT in next.config.js, which has no verdictops redirect; confirm via browser or curl)
-- [ ] Fix hardcoded `noreply@verdictops.com` fallback in two API routes (post-merger cleanup):
-  - `app/api/screenapp-webhook/route.ts` line 71
-  - `app/api/receptionist/call-complete/route.ts` line 59
-  - Replace fallback with `noreply@counterbench.ai`
+- [x] Verify verdictops.com 301 -> counterbench.ai/paralegals is live — VERIFIED 2026-06-30 via curl: verdictops.com 307→www.verdictops.com 308→counterbench.ai/paralegals→200. Redirect live and functional (307/308 not literal 301, lands correct).
+- [x] Fix hardcoded `noreply@verdictops.com` fallback in two API routes — ALREADY DONE (verified 2026-06-30). Both files now use `process.env.RESEND_FROM || "noreply@counterbench.ai"`:
+  - `app/api/screenapp-webhook/route.ts` line 84 ✓
+  - `app/api/receptionist/call-complete/route.ts` line 70 ✓
+  - No `verdictops.com` string remains anywhere in CB codebase.
 - [ ] GTM Preview mode — verify all dataLayer tags fire on counterbench.ai
 - [ ] Meta Pixel Helper — verify fbq events
 - [ ] GA4 DebugView — confirm events arrive
@@ -61,3 +61,13 @@
 ### Build status
 - Last confirmed clean build: 2026-03-19 (per todo.md history — `tsc --noEmit` clean, `next build` clean)
 - Scripts: `npm run typecheck` (tsc --noEmit), `npm run build` (next build)
+
+### E2E suite repair — 2026-07-06
+- [x] Triage 23 "failing" Playwright specs → root cause: Grafana listens on port 3000; `reuseExistingServer: true` made the whole suite run against Grafana, not the app. No specs were stale; app was never broken.
+- [x] Fix: `playwright.config.ts` default e2e port moved 3000 → 3100 (`E2E_PORT` env override; `E2E_BASE_URL` still wins).
+- [x] Deleted `tests/e2e/receptionist.spec.ts` (untracked, never committed): its `page.route()` mocks never intercept `page.request.*` (APIRequestContext bypasses route handlers), so all 17 tests were self-mocking theater hitting the real server; real mode would need ADMIN_API_KEY and would write test rows to prod Neon. Contract coverage: `__tests__/receptionist-admin.test.ts` + `__tests__/receptionist-call-flow.test.ts` + new `__tests__/receptionist-calls.test.ts` (GET /api/receptionist/calls had zero coverage after the deletion).
+- [ ] Backlog: real HTTP-layer e2e for receptionist routes (URL→handler wiring, [id] params) — gated on a test-DB story; do not point tests at prod Neon.
+- [ ] **SECURITY (found in review, needs decision): `GET /api/receptionist/calls` is unauthenticated** and returns the last 100 call records — transcripts + caller phone numbers (PI-intake PII) — to anyone. Needs auth guard (x-admin-key like admin routes) or removal if unused.
+- [x] Result: `npm run e2e` → 15 passed, 3 skipped (visual capture, opt-in via VISUAL=1), 0 failed.
+- [x] Stale worktree `.claude/worktrees/stupefied-goldwasser-08fca0/` removed + branch deleted; its one unique file salvaged to `adr/legal-pi-review.md`.
+- Gotcha for future runs: a squatted port + reuseExistingServer silently tests the wrong application. Now guarded automatically: `tests/e2e/global-setup.ts` asserts the server at baseURL is actually Counterbench before any test runs, and `reuseExistingServer` is disabled in CI.

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,28 @@
+import type { FullConfig } from "@playwright/test";
+
+/**
+ * Identity guard for the system under test.
+ *
+ * reuseExistingServer means any process already listening on the e2e port
+ * silently becomes the SUT (this suite once ran 35 tests against Grafana on
+ * port 3000; 3100 is Loki's default, so moving ports alone doesn't close the
+ * class). Before any test runs, assert the server at baseURL is actually the
+ * Counterbench app — fail loud with the real cause instead of a wall of
+ * misleading locator timeouts.
+ */
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL;
+  if (!baseURL) return;
+
+  const res = await fetch(baseURL);
+  const html = await res.text();
+
+  if (!/counterbench/i.test(html)) {
+    const title = html.match(/<title>([^<]*)<\/title>/i)?.[1] ?? "(no title)";
+    throw new Error(
+      `E2E identity check failed: ${baseURL} is serving "${title}", not the Counterbench app. ` +
+        `Another process is likely squatting the port (reuseExistingServer treats it as the SUT). ` +
+        `Free the port or set E2E_PORT to an unused one.`
+    );
+  }
+}


### PR DESCRIPTION
## Problem

`npm run e2e` reported 23/35 failures that looked like app/test drift. Actual cause: Grafana listens on port 3000 on the dev machine, and Playwright's `reuseExistingServer: true` treated it as the app under test — the whole suite ran against Grafana's login page. The 9 "passes" were accidents (Grafana 401s happened to match auth-guard expectations). No specs were stale; the app was never broken.

## Changes

- Default e2e port 3000 → 3100, overridable via `E2E_PORT` (`E2E_BASE_URL` behavior unchanged)
- `reuseExistingServer` disabled in CI so a squatted port fails loud instead of silently testing the wrong process
- New `tests/e2e/global-setup.ts` identity guard: asserts the server at baseURL is actually Counterbench before any test runs. Negative-tested against Grafana itself — fails with `E2E identity check failed: ...serving "Grafana"` instead of a wall of locator timeouts. Closes the bug class (3100 is Loki's default port, so moving ports alone wasn't enough)
- Salvaged `adr/legal-pi-review.md` from a removed stale worktree
- `tasks/todo.md`: repair log, backlog notes, and a security finding

Also removed `tests/e2e/receptionist.spec.ts` (untracked, never committed): its `page.route()` mocks never intercept `page.request.*` calls (APIRequestContext bypasses route handlers), so all 17 tests asserted their own mocks. Contract coverage lives in the receptionist vitest suites.

## Verification

- E2E: 15 passed, 3 skipped (opt-in visual via `VISUAL=1`), 0 failed
- Full gate green: typecheck, lint, vitest (65), build
- Identity guard negative test: pointed at Grafana on 3000, failed loud with correct message
- Review cascade (critic 7/10, bloat 8/10, deep-review 7/10 — all approved, findings addressed): `.orchestra/evidence.jsonl`, task_id `e2e-suite-repair-port3100`

## Related

- Security finding from review, handled separately: `GET /api/receptionist/calls` is unauthenticated and returns call transcripts + caller phone numbers. Auth fix in flight in a separate session.