### PR TITLE
feat: forward newsletter leads to n8n Slack notifier

### DIFF
--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -188,5 +188,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, message: "Subscription failed. Try again in a moment." }, { status: 502 });
   }
 
+  // Fire-and-forget lead forward to n8n (Slack notifier). Never blocks, never throws.
+  try {
+    if (process.env.N8N_LEAD_WEBHOOK_URL) {
+      fetch(process.env.N8N_LEAD_WEBHOOK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ business: "CounterbenchAI", cta: "Newsletter", email: email.trim() })
+      }).catch(() => {});
+    }
+  } catch {}
+
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## What changed
Adds a fire-and-forget forward to n8n in `app/api/newsletter/subscribe/route.ts`. After the Beehiiv subscribe fetch succeeds (right before the final `NextResponse.json({ ok: true })`), the route POSTs the lead to an n8n webhook that fires a Slack notification.

Payload: `{ business: "CounterbenchAI", cta: "Newsletter", email }` (trimmed submitted email; this route captures no name).

## Requirements
- Requires env var `N8N_LEAD_WEBHOOK_URL = https://petrichorprojects.app.n8n.cloud/webhook/lead-intake` set in the host.
- Inert until that var is set **and** the n8n workflow is active — with no var, the block is skipped entirely.

## Safety
- Fire-and-forget: the call is not awaited, wrapped in `try/catch` with a `.catch(() => {})` on the promise. It never blocks the response and never throws.
- Does not affect the existing Beehiiv subscribe flow or any response returned to the client.

## Not covered
- The contact CTA is a bare `mailto:` with no backend, so contact-form requests are **not** forwarded by this change. Newsletter signups only.