### PR TITLE
feat: real contact form (replaces mailto) + fix dropped n8n forwards

### DIFF
--- a/app/(marketing)/contact/page.tsx
+++ b/app/(marketing)/contact/page.tsx
@@ -1,3 +1,5 @@
+import { ContactForm } from "@/components/ContactForm";
+
 export const metadata = { title: "Contact" };
 
 export default function ContactPage() {
@@ -8,12 +10,12 @@ export default function ContactPage() {
           <div className="label">Contact</div>
           <h1 className="max-w-900">Get in touch.</h1>
           <p className="max-w-700 mt-4" style={{ fontSize: "1.125rem" }}>
-            For partnerships, listings, or advisory requests, email{" "}
+            For partnerships, listings, or advisory requests, use the form below — or email{" "}
             <a href="mailto:hello@counterbench.ai">hello@counterbench.ai</a>.
           </p>
+          <ContactForm source="contact-page" />
         </div>
       </section>
     </main>
   );
 }
-

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -85,6 +85,30 @@ function str(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
 
+/**
+ * Forward the lead to n8n (which posts it to Slack).
+ *
+ * This MUST be awaited. On serverless the runtime is frozen as soon as the
+ * handler returns, so a fire-and-forget fetch is silently dropped and the
+ * lead never arrives. Bounded by a timeout and never throws, so a slow or
+ * down n8n cannot fail the visitor's submission.
+ */
+async function forwardToN8n(payload: Record<string, unknown>): Promise<void> {
+  const url = process.env.N8N_LEAD_WEBHOOK_URL;
+  if (!url) return;
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error({ event: "contact_n8n_forward_failed", err });
+  }
+}
+
 async function readBody(req: Request): Promise<ContactBody> {
   const ct = req.headers.get("content-type") || "";
 
@@ -156,23 +180,15 @@ export async function POST(req: Request) {
   // Notify Slack via n8n BEFORE sending mail. A contact request is a lead —
   // it must surface even if Resend is unconfigured or erroring, which is the
   // failure mode that would otherwise lose it silently.
-  try {
-    if (process.env.N8N_LEAD_WEBHOOK_URL) {
-      fetch(process.env.N8N_LEAD_WEBHOOK_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          business: "CounterbenchAI",
-          cta: `Contact — ${topic}`,
-          name,
-          email,
-          message,
-          ...(firm ? { firm } : {}),
-          ...(source ? { source } : {})
-        })
-      }).catch(() => {});
-    }
-  } catch {}
+  await forwardToN8n({
+    business: "CounterbenchAI",
+    cta: `Contact — ${topic}`,
+    name,
+    email,
+    message,
+    ...(firm ? { firm } : {}),
+    ...(source ? { source } : {})
+  });
 
   const apiKey = process.env.RESEND_API_KEY;
   if (!apiKey) {

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,215 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+
+// Force dynamic — prevents build-time evaluation of this module.
+// Without this, missing RESEND_API_KEY at build breaks `next build`
+// during page-data collection.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// ---------------------------------------------------------------------------
+// In-memory rate limiter: 5 POSTs per IP per hour.
+// Entries auto-expire so the map doesn't grow unbounded.
+// ---------------------------------------------------------------------------
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+
+const ipHits = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const timestamps = (ipHits.get(ip) ?? []).filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+
+  if (timestamps.length >= RATE_LIMIT_MAX) {
+    ipHits.set(ip, timestamps);
+    return true;
+  }
+
+  timestamps.push(now);
+  ipHits.set(ip, timestamps);
+  return false;
+}
+
+// Periodic cleanup every 10 minutes to prevent unbounded growth.
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, timestamps] of ipHits) {
+    const valid = timestamps.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (valid.length === 0) {
+      ipHits.delete(ip);
+    } else {
+      ipHits.set(ip, valid);
+    }
+  }
+}, 10 * 60 * 1000).unref();
+
+function getClientIp(req: Request): string {
+  // Vercel sets x-forwarded-for; fall back to x-real-ip.
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0];
+    return first ? first.trim() : "unknown";
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TOPICS = ["Partnership", "Tool listing", "Advisory", "Other"] as const;
+
+const MAX_NAME = 120;
+const MAX_FIRM = 160;
+const MAX_MESSAGE = 5000;
+
+function isValidEmail(email: string): boolean {
+  if (!email) return false;
+  const e = email.trim();
+  if (e.length < 5 || e.length > 254) return false;
+  // Lightweight validation; the mail provider will validate further.
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
+}
+
+type ContactBody = {
+  name: string;
+  email: string;
+  firm: string;
+  topic: string;
+  message: string;
+  source: string;
+  hp: string;
+};
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+async function readBody(req: Request): Promise<ContactBody> {
+  const ct = req.headers.get("content-type") || "";
+
+  if (ct.includes("application/json")) {
+    const j = (await req.json().catch(() => ({}))) as Record<string, unknown>;
+    return {
+      name: str(j.name),
+      email: str(j.email),
+      firm: str(j.firm),
+      topic: str(j.topic),
+      message: str(j.message),
+      source: str(j.source),
+      hp: str(j.hp)
+    };
+  }
+
+  const fd = await req.formData().catch(() => null);
+  if (!fd) {
+    return { name: "", email: "", firm: "", topic: "", message: "", source: "", hp: "" };
+  }
+  return {
+    name: str(fd.get("name")),
+    email: str(fd.get("email")),
+    firm: str(fd.get("firm")),
+    topic: str(fd.get("topic")),
+    message: str(fd.get("message")),
+    source: str(fd.get("source")),
+    hp: str(fd.get("company")) // honeypot
+  };
+}
+
+export async function POST(req: Request) {
+  // --- Rate limit check (before parsing body) ---
+  const clientIp = getClientIp(req);
+  if (isRateLimited(clientIp)) {
+    return NextResponse.json(
+      { ok: false, message: "Too many requests. Please try again later." },
+      { status: 429 }
+    );
+  }
+
+  const body = await readBody(req);
+
+  // Honeypot: pretend success for bots.
+  if (body.hp.trim()) {
+    return NextResponse.json({ ok: true });
+  }
+
+  const name = body.name.trim().slice(0, MAX_NAME);
+  const email = body.email.trim();
+  const firm = body.firm.trim().slice(0, MAX_FIRM);
+  const message = body.message.trim().slice(0, MAX_MESSAGE);
+  const topic = (TOPICS as readonly string[]).includes(body.topic) ? body.topic : "Other";
+  const source = body.source.trim().slice(0, 120);
+
+  if (!name) {
+    return NextResponse.json({ ok: false, message: "Enter your name." }, { status: 400 });
+  }
+  if (!isValidEmail(email)) {
+    return NextResponse.json({ ok: false, message: "Enter a valid email." }, { status: 400 });
+  }
+  if (message.length < 10) {
+    return NextResponse.json(
+      { ok: false, message: "Tell us a bit more about what you need." },
+      { status: 400 }
+    );
+  }
+
+  // Notify Slack via n8n BEFORE sending mail. A contact request is a lead —
+  // it must surface even if Resend is unconfigured or erroring, which is the
+  // failure mode that would otherwise lose it silently.
+  try {
+    if (process.env.N8N_LEAD_WEBHOOK_URL) {
+      fetch(process.env.N8N_LEAD_WEBHOOK_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          business: "CounterbenchAI",
+          cta: `Contact — ${topic}`,
+          name,
+          email,
+          message,
+          ...(firm ? { firm } : {}),
+          ...(source ? { source } : {})
+        })
+      }).catch(() => {});
+    }
+  } catch {}
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error({ event: "contact_no_resend_key" });
+    // Slack already has the lead; don't fail the visitor's submission.
+    return NextResponse.json({ ok: true });
+  }
+
+  const submittedAt = new Date().toLocaleString("en-US", { timeZone: "America/New_York" });
+
+  try {
+    const resend = new Resend(apiKey);
+    await resend.emails.send({
+      from: process.env.RESEND_FROM || "noreply@counterbench.ai",
+      to: process.env.CONTACT_TO || "hello@counterbench.ai",
+      replyTo: email,
+      subject: `Contact — ${topic} | ${name}`,
+      text: [
+        `New contact request from counterbench.ai`,
+        ``,
+        `Name: ${name}`,
+        `Email: ${email}`,
+        firm ? `Firm: ${firm}` : null,
+        `Topic: ${topic}`,
+        source ? `Source: ${source}` : null,
+        `Received: ${submittedAt} ET`,
+        ``,
+        `Message:`,
+        message
+      ]
+        .filter((line) => line !== null)
+        .join("\n")
+    });
+  } catch (err) {
+    console.error({ event: "contact_email_error", err });
+    // Slack already has the lead; don't fail the visitor's submission.
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+const TOPICS = ["Partnership", "Tool listing", "Advisory", "Other"] as const;
+
+const fieldStyle = {
+  width: "100%",
+  padding: "12px 14px",
+  borderRadius: 12,
+  border: "1px solid var(--border)",
+  background: "var(--bg2)",
+  color: "var(--fg)"
+} as const;
+
+export function ContactForm({ source = "contact-page" }: { source?: string }) {
+  const [status, setStatus] = useState<"idle" | "loading" | "ok" | "error">("idle");
+  const [message, setMessage] = useState<string>("");
+
+  if (status === "ok") {
+    return (
+      <div aria-live="polite" style={{ marginTop: "1.5rem" }}>
+        <p style={{ fontSize: "1.125rem" }}>Thanks — we got it.</p>
+        <p className="text-muted" style={{ fontSize: "0.9375rem" }}>
+          We reply to most requests within one business day.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      style={{ marginTop: "1.5rem", maxWidth: 640 }}
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const form = e.currentTarget;
+        const fd = new FormData(form);
+
+        // Bot honeypot — pretend success.
+        const hp = String(fd.get("company") || "");
+        if (hp.trim()) {
+          setStatus("ok");
+          return;
+        }
+
+        setStatus("loading");
+        setMessage("");
+
+        try {
+          const res = await fetch("/api/contact", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", Accept: "application/json" },
+            body: JSON.stringify({
+              name: String(fd.get("name") || "").trim(),
+              email: String(fd.get("email") || "").trim(),
+              firm: String(fd.get("firm") || "").trim(),
+              topic: String(fd.get("topic") || "Other"),
+              message: String(fd.get("message") || "").trim(),
+              source,
+              hp
+            })
+          });
+
+          const data = (await res.json().catch(() => ({}))) as { message?: string };
+
+          if (!res.ok) {
+            setStatus("error");
+            setMessage(data.message || "Something went wrong. Try again in a moment.");
+            return;
+          }
+
+          setStatus("ok");
+          window.dataLayer = window.dataLayer || [];
+          window.dataLayer.push({ event: "contact_submit", contact_source: source });
+          form.reset();
+        } catch {
+          setStatus("error");
+          setMessage("Network error. Please try again.");
+        }
+      }}
+    >
+      {/* Honeypot — hidden from humans, tempting to bots. */}
+      <input
+        tabIndex={-1}
+        autoComplete="off"
+        name="company"
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: -10000,
+          top: "auto",
+          width: 1,
+          height: 1,
+          overflow: "hidden"
+        }}
+      />
+
+      <div className="flex flex--gap-2 flex--resp-col" style={{ marginBottom: "0.75rem" }}>
+        <div style={{ width: "100%" }}>
+          <label htmlFor="contact-name" style={{ display: "block", marginBottom: 6 }}>
+            Name
+          </label>
+          <input id="contact-name" name="name" type="text" required maxLength={120} style={fieldStyle} />
+        </div>
+        <div style={{ width: "100%" }}>
+          <label htmlFor="contact-email" style={{ display: "block", marginBottom: 6 }}>
+            Email
+          </label>
+          <input
+            id="contact-email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            inputMode="email"
+            placeholder="you@firm.com"
+            style={fieldStyle}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex--gap-2 flex--resp-col" style={{ marginBottom: "0.75rem" }}>
+        <div style={{ width: "100%" }}>
+          <label htmlFor="contact-firm" style={{ display: "block", marginBottom: 6 }}>
+            Firm <span className="text-muted">(optional)</span>
+          </label>
+          <input id="contact-firm" name="firm" type="text" maxLength={160} style={fieldStyle} />
+        </div>
+        <div style={{ width: "100%" }}>
+          <label htmlFor="contact-topic" style={{ display: "block", marginBottom: 6 }}>
+            Reason
+          </label>
+          <select id="contact-topic" name="topic" defaultValue="Advisory" style={fieldStyle}>
+            {TOPICS.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div style={{ marginBottom: "1rem" }}>
+        <label htmlFor="contact-message" style={{ display: "block", marginBottom: 6 }}>
+          What do you need?
+        </label>
+        <textarea
+          id="contact-message"
+          name="message"
+          required
+          rows={5}
+          maxLength={5000}
+          placeholder="A few sentences is plenty."
+          style={{ ...fieldStyle, resize: "vertical" }}
+        />
+      </div>
+
+      <button className="btn btn--primary" type="submit" disabled={status === "loading"}>
+        {status === "loading" ? "Sending…" : "Send"}
+      </button>
+
+      <div
+        className="text-muted"
+        style={{ fontSize: "0.8125rem", marginTop: "0.75rem" }}
+        aria-live="polite"
+      >
+        {message ? (
+          message
+        ) : (
+          <>
+            We&rsquo;ll only use this to reply.{" "}
+            <Link href="/privacy" className="text-muted" style={{ textDecoration: "underline" }}>
+              Privacy
+            </Link>
+            .
+          </>
+        )}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Why

The contact CTA was a bare `mailto:hello@counterbench.ai`. Inbound requests landed in an inbox with **no Slack signal and no record** — the biggest gap in the new lead pipeline. A PI firm reaching out was invisible everywhere else.

## What

- **`POST /api/contact`** — rate limited (5/IP/hour), honeypot, validation, Resend notification with `replyTo` set to the sender, plus an n8n → Slack forward.
- **`components/ContactForm.tsx`** — client form (name, email, firm, reason, message). Mirrors `NewsletterCapture` conventions: same honeypot field name, `{ok, message}` response handling, `dataLayer` push, inline styles using existing CSS vars.
- **Contact page** now renders the form; the mailto stays as a fallback.

Reuses the newsletter route's existing rate-limiter / `getClientIp` / `isValidEmail` / `readBody` patterns rather than inventing new ones.

### Ordering: n8n before Resend

The forward fires **before** the email send, so a contact request still reaches Slack if Resend is unconfigured or erroring. The newsletter route has the opposite order — a failed Beehiiv call means no alert at all. For contact, losing the lead is the worse outcome.

## The serverless bug this uncovered

The first preview returned `200` but produced **zero n8n executions**. Cause: an un-awaited `fetch` is silently dropped — the serverless runtime freezes on handler return and kills the dangling promise. It only appeared to work in `mettle/api/lead.ts` by luck, because that handler does awaited Resend work afterward which keeps the runtime alive.

Fixed here by awaiting the forward with a 3s `AbortSignal.timeout`, still never throwing, so a slow or down n8n cannot fail the visitor's submission.

⚠️ **The same flaw exists in the already-merged forwards** in `app/api/newsletter/subscribe/route.ts`, `petrichor-projects`, `reality-audit`, and `mettle`. Being fixed in follow-up PRs.

## Verified on the preview deploy

| Test | Result |
|---|---|
| `GET /contact` | 200, form renders |
| short message | 400 `"Tell us a bit more about what you need."` |
| honeypot filled | 200 `{ok:true}`, **no n8n execution** ✅ |
| real submission | 200 in 1.4s → n8n execution `1103` → Slack ✅ |

`tsc --noEmit` clean.