### PR TITLE
fix: await n8n lead forward — fire-and-forget is dropped on serverless

### DIFF
--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -103,6 +103,29 @@ function getConfigStatus() {
   };
 }
 
+/**
+ * Forward the lead to n8n (which posts it to Slack).
+ *
+ * This MUST be awaited. On serverless the runtime is frozen as soon as the
+ * handler returns, so a fire-and-forget fetch is silently dropped and the
+ * lead never arrives. Bounded by a timeout and never throws, so a slow or
+ * down n8n cannot fail the user's request.
+ */
+async function forwardToN8n(payload: Record<string, unknown>): Promise<void> {
+  const url = process.env.N8N_LEAD_WEBHOOK_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(3000)
+    });
+  } catch (err) {
+    console.error({ event: "n8n_forward_failed", err });
+  }
+}
+
 export async function GET() {
   // Safe status endpoint (no secrets) to debug env wiring without creating a subscription.
   return NextResponse.json({ ok: true, ...getConfigStatus() });
@@ -188,16 +211,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, message: "Subscription failed. Try again in a moment." }, { status: 502 });
   }
 
-  // Fire-and-forget lead forward to n8n (Slack notifier). Never blocks, never throws.
-  try {
-    if (process.env.N8N_LEAD_WEBHOOK_URL) {
-      fetch(process.env.N8N_LEAD_WEBHOOK_URL, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ business: "CounterbenchAI", cta: "Newsletter", email: email.trim() })
-      }).catch(() => {});
-    }
-  } catch {}
+  // Lead forward to n8n (Slack notifier). Awaited: the response below ends the
+  // invocation, which on serverless freezes the runtime and drops any in-flight
+  // un-awaited fetch. Bounded by a timeout and never throws.
+  await forwardToN8n({ business: "CounterbenchAI", cta: "Newsletter", email: email.trim() });
 
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## The bug

`app/api/newsletter/subscribe/route.ts` forwarded newsletter leads to the n8n webhook with an un-awaited fetch:

```js
fetch(process.env.N8N_LEAD_WEBHOOK_URL, { ... }).catch(() => {});
```

On Vercel serverless the runtime is frozen the moment the handler returns, so the in-flight request is silently dropped and **the lead never reaches n8n**. The block sat directly before the final `return NextResponse.json({ ok: true })`, so the fetch was killed almost immediately after being started.

## Evidence

Proven empirically on an equivalent handler:

- Fire-and-forget version: HTTP **200** returned, **zero** n8n executions.
- Awaited version: n8n **execution 1103** + Slack message delivered.

The user-visible symptom is the worst kind: the subscribe call looks completely healthy (200, Beehiiv subscription succeeds) while the Slack notification never arrives.

## The fix

Added a `forwardToN8n` helper and **awaited** it before the handler responds:

- **Awaited** — the request completes before the runtime can freeze.
- **3s bounded timeout** via `AbortSignal.timeout(3000)` — a slow n8n cannot hang the subscriber's request.
- **Never throws** — failures are caught and logged as `n8n_forward_failed`, so a down n8n cannot fail a subscription that already succeeded at Beehiiv.

**Payload unchanged** — still exactly `{ business: "CounterbenchAI", cta: "Newsletter", email: email.trim() }`.

Placement is unchanged too: still after the Beehiiv success check, so it only fires for genuinely successful subscriptions.

## Scope

Only `app/api/newsletter/subscribe/route.ts` changed. No other edits, no reformatting.

This is intentionally **self-contained on its own branch off `main`** and does not depend on `feat/counterbench-contact-form` (#21), which adds an equivalent helper to `app/api/contact/route.ts`. The small duplication is deliberate so this fix can ship independently. If both land, the two helpers are trivially de-dupable into a shared module in a follow-up.

## Verification

`npm install` then `npx tsc --noEmit` exits **0**. Confirmed the check actually covers this file: `tsc --listFiles` includes `app/api/newsletter/subscribe/route.ts` in the program (the tsconfig has `include: ["**/*.ts", ...]` with `types: ["node"]`), and `AbortSignal.timeout` typechecks cleanly under `lib: ["DOM", "DOM.Iterable", "ES2022"]`.