### PR TITLE
feat(pricing): agent-readable pricing.md + Paralegal Teams in llms.txt

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,56 @@
+# CounterbenchAI — Ubiquitous Language
+
+**Last updated:** 2026-07-17
+**Maintained by:** Phil & Claude
+**Domain:** Legal AI platform + paralegal teams for PI law firms
+
+> Single source of truth for terminology. All Claude sessions on CounterbenchAI use these terms. VerdictOps merged into CounterbenchAI as of 2026-04-22 — verdictops.com 301s to counterbench.ai/paralegals.
+
+## Core Terms
+
+| Term | Definition | Don't Say Instead |
+|------|-----------|-------------------|
+| **Tool Directory** | The free, public-facing section of counterbench.ai. Curated directory of AI tools relevant to PI law firms. Drives organic traffic and builds trust. | "Product catalog", "marketplace", "app store" |
+| **Paralegal Teams** | The paid service arm. Human paralegal teams augmented with AI tools, sold on retainer ($3,750-$6,500/mo). This is where revenue comes from. | "Staffing", "outsourcing", "virtual assistants" |
+| **Counter-Narrative** | CounterbenchAI's positioning thesis: "AI tools AND the team to run them — you don't have to choose." Competitors offer one or the other. | Don't dilute — use the exact phrase when positioning |
+| **ICP (Ideal Client Profile)** | PI law firms, solo to 10-attorney, with paralegal understaffing. Firms that know they need help but can't hire fast enough. | "Target market", "audience" (too vague) |
+| **Retainer** | The monthly engagement model. Firms pay $3,750-$6,500/mo for a dedicated paralegal team. NOT project-based billing. | "Subscription", "monthly fee" (too SaaS-y) |
+| **VerdictOps** | The former brand for the services arm. Now a 301 redirect to counterbench.ai/paralegals. Domain still owned. Don't create new content under VerdictOps brand. | Don't use as a current brand name |
+
+## Buyer Language
+
+| Term | Definition |
+|------|-----------|
+| **Firm** | Always "firm", never "company" or "business" when referring to a law practice. |
+| **Attorney** | The decision-maker. Usually managing partner at solo-to-10 firms. |
+| **Paralegal Understaffing** | The core pain point. Firms can't hire enough qualified paralegals. Turnover is high. AI alone doesn't solve this — you need humans who know how to use the AI. |
+| **Case Volume** | What firms care about. More cases processed = more revenue. Paralegal capacity is the bottleneck. |
+
+## Service Tiers
+
+> Source of truth: `app/(marketing)/paralegals/page.tsx` (`tiers` const). If this table and the page disagree, the page wins — update this table.
+
+| Tier | Price | What's Included |
+|------|-------|-----------------|
+| **Core** | $3,750/mo | Dedicated paralegal pod, intake + client communication, record requests, medical chronologies, weekly QA. Up to 80-120 hours/month. |
+| **Scale** | Starting at $6,500/mo | Everything in Core plus litigation drafting, demand packet assembly, priority handling, dedicated account manager, custom workflow integration. 120-160+ hours/month. |
+
+> Pricing positions against hiring a full-time paralegal ($45-65k/yr + benefits + training + turnover risk). Retainer is cheaper and more flexible.
+
+## Content & SEO Terms
+
+| Term | Definition |
+|------|-----------|
+| **Reddit Intel** | Insights mined from r/legaltech, r/paralegal, r/LawFirm. Drives content topics and objection handling. |
+| **PI** | Personal Injury. The legal specialty our ICP practices. Always spell out on first use in any public content. |
+| **Intake** | The process of qualifying new potential cases at a firm. A major paralegal workflow — common upsell angle. |
+
+## Anti-Terms
+
+| Banned | Why | Use Instead |
+|--------|-----|-------------|
+| "AI-powered" (standalone) | Empty buzzword for legal audience | Name the specific capability |
+| "Virtual assistant" | Sounds cheap, undermines paralegal positioning | "Paralegal team" |
+| "Platform" (for services) | Confuses tool directory with services | "Paralegal Teams" for services, "Tool Directory" for the directory |
+| "Outsourcing" | Negative connotation in legal | "Dedicated paralegal team" |
+| "Disrupting legal" | Lawyers hate this | "Augmenting your practice" |

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,6 +1,6 @@
 # Counterbench.AI
 
-Counterbench.AI is a curated directory of legal AI tools plus prompt templates and playbooks for paralegals, law firms, solo lawyers, and legal researchers.
+Counterbench.AI is a curated directory of legal AI tools plus prompt templates and playbooks for paralegals, law firms, solo lawyers, and legal researchers. Counterbench also operates Paralegal Teams: managed human paralegal pods, augmented with AI tools, available on monthly retainer to personal injury law firms. AI tools AND the team to run them - you don't have to choose.
 
 Primary domain: https://counterbench.ai
 
@@ -27,6 +27,7 @@ Primary domain: https://counterbench.ai
 - Resources: https://counterbench.ai/resources
 - Advisory: https://counterbench.ai/advisory
 - Paralegal Teams (managed human paralegals + AI): https://counterbench.ai/paralegals
+- Pricing (machine-readable markdown): https://counterbench.ai/pricing.md
 
 ## Crawling / Discovery
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -26,6 +26,7 @@ Primary domain: https://counterbench.ai
 - Playbooks: https://counterbench.ai/playbooks
 - Resources: https://counterbench.ai/resources
 - Advisory: https://counterbench.ai/advisory
+- Paralegal Teams (managed human paralegals + AI): https://counterbench.ai/paralegals
 
 ## Crawling / Discovery
 

--- a/public/pricing.md
+++ b/public/pricing.md
@@ -1,0 +1,93 @@
+# CounterbenchAI Pricing
+
+As of July 2026. Prices in USD. Canonical human-readable pages: https://counterbench.ai/paralegals and https://counterbench.ai/advisory
+
+CounterbenchAI provides AI-enabled paralegal teams and retained AI advisory for personal injury law firms, plus a free legal AI tool directory.
+
+## Paralegal Teams (primary service)
+
+Dedicated paralegal pods for PI firms. Intake, records, medical chronologies, and client communication, with AI built into how the team works. Live in 2-3 weeks from signed agreement.
+
+Page: https://counterbench.ai/paralegals
+CTA: Book a discovery call at https://counterbench.ai/contact
+
+### Core: $3,750 per month
+
+- Who qualifies: solo practitioners and 2-4 attorney firms handling 20-40 cases per month
+- Capacity: up to 80-120 hours per month
+- Included:
+  - Dedicated paralegal pod
+  - Intake and client communication management
+  - Record requests and tracking
+  - Medical chronology preparation
+  - Case status reporting and updates
+  - Weekly quality assurance
+- Replaces roughly half to three quarters of a full-time paralegal (salary plus benefits: $55K-65K; typical recruiting timeline: 3-6 months)
+
+### Scale: starting at $6,500 per month
+
+- Who qualifies: 4-10 attorney firms with high-volume caseloads
+- Capacity: 120-160+ hours per month
+- Included:
+  - Everything in Core
+  - Litigation document drafting and support
+  - Demand packet assembly and indexing
+  - Priority request handling and expedited turnaround
+  - Legal research and case analysis support
+  - Dedicated account manager
+  - Advanced reporting and analytics
+  - Custom workflow integration
+- Replaces 1-2 full-time paralegals (annual cost: $110K-170K including salary, benefits, and recruiting)
+
+### Add-ons
+
+| Add-on | Price | Unit |
+|---|---|---|
+| Extra 20-hour block | $850 | one-time |
+| Rush / same-day request | $250 | per request |
+| Medical chronology | $750 | flat fee |
+| Demand package assembly | $500 | flat fee |
+| After-hours coverage (evenings and weekends) | $400 | per month |
+
+### Terms
+
+- Month-to-month. No long-term contracts. Cancel with 30 days' notice.
+- Typical go-live: 2-3 weeks from signed agreement.
+- SOC 2 Type II certified, US-hosted, encrypted at rest and in transit. All team members sign NDAs.
+- Integrates with most PI case management systems, including Clio, CaseWare, Centerbase, and MyCase, plus email, Slack, Google Drive, and OneDrive.
+
+## AI Advisory (retained strategy)
+
+Retained AI strategy advisory for plaintiff trial firms. Vendor evaluation, workflow architecture, and implementation sequencing. No software sales, no vendor commissions. All engagements are month-to-month after the initial 90-day engagement.
+
+Page: https://counterbench.ai/advisory
+
+### Orientation: $1,500 per month
+
+- Who qualifies: smaller firms at the start of AI adoption that need strategic clarity and a prioritized roadmap without full implementation support
+- Included: monthly 90-minute strategy session, AI readiness assessment, vendor briefing, prioritized action list
+
+### Full Advisory: $3,500 per month
+
+- Who qualifies: firms ready for the core engagement, from diagnostic through implementation
+- Included: everything in Orientation, plus 90-day engagement roadmap, custom role-based SOPs, vendor evaluation matrix, prompt library (50+ prompts), bi-weekly strategy sessions
+
+### Strategic Partner: $7,500 per month
+
+- Who qualifies: multi-location or high-volume firms that need embedded, ongoing partnership rather than a consulting cycle
+- Included: everything in Full Advisory, plus unlimited async access, staff training sessions, quarterly firm review, priority response under 4 hours, competitive intelligence briefings
+
+## Free resources
+
+No charge, no account required:
+
+- Legal AI tools directory: https://counterbench.ai/tools
+- Tool comparisons: https://counterbench.ai/tools/compare
+- Prompt templates: https://counterbench.ai/prompts
+- Workflow playbooks: https://counterbench.ai/playbooks
+- Guides: https://counterbench.ai/guides
+
+## Contact
+
+- Book a discovery call: https://counterbench.ai/contact
+- Site: https://counterbench.ai

--- a/scripts/check-pricing-drift.mjs
+++ b/scripts/check-pricing-drift.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * check-pricing-drift.mjs
+ *
+ * Guards against pricing drift between the live pricing pages and the
+ * agent-readable pricing surface (public/pricing.md, per PRD-agent-readable-pricing).
+ *
+ * What it does:
+ *   1. Extracts tier names + prices from:
+ *        - app/(marketing)/paralegals/page.tsx  (the `tiers` const, plus `addOns`)
+ *        - app/(marketing)/advisory/page.tsx    (the pricing-name / pricing-price JSX)
+ *   2. If public/pricing.md exists:
+ *        - every dollar figure in pricing.md must appear somewhere in the pages
+ *        - every extracted TIER price must appear in pricing.md
+ *      On any mismatch: prints a diff-style report and exits 1.
+ *   3. If public/pricing.md does not exist: prints "no pricing.md, skipping"
+ *      and exits 0.
+ *
+ * Usage (from repo root):
+ *   node scripts/check-pricing-drift.mjs
+ *
+ * Deliberately NOT wired into the package.json build. Run it manually before
+ * committing pricing changes, or wire it into CI once pricing.md ships.
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const PARALEGALS = join(root, "app", "(marketing)", "paralegals", "page.tsx");
+const ADVISORY = join(root, "app", "(marketing)", "advisory", "page.tsx");
+const PRICING_MD = join(root, "public", "pricing.md");
+
+/** Normalize a dollar string for comparison: "$6,500/mo" -> "$6500". */
+function normalize(dollar) {
+  const m = dollar.match(/\$\s?([\d,]+(?:\.\d+)?)\s*([KkMm])?/);
+  if (!m) return null;
+  return "$" + m[1].replace(/,/g, "") + (m[2] ? m[2].toUpperCase() : "");
+}
+
+/** All dollar figures in a string, normalized. */
+function allDollars(text) {
+  const out = new Set();
+  for (const m of text.matchAll(/\$\s?[\d][\d,]*(?:\.\d+)?[KkMm]?/g)) {
+    const n = normalize(m[0]);
+    if (n) out.add(n);
+  }
+  return out;
+}
+
+/** Slice out a `const NAME = [ ... ];` block from a source file. */
+function constBlock(source, name) {
+  const start = source.indexOf(`const ${name} = [`);
+  if (start === -1) return "";
+  const end = source.indexOf("];", start);
+  return end === -1 ? "" : source.slice(start, end);
+}
+
+/** Extract { name, price } pairs from an array-of-objects const block. */
+function extractPairs(block) {
+  const pairs = [];
+  // Objects are separated by "},"; each carries name: "..." and price: "..."
+  for (const chunk of block.split(/\}\s*,/)) {
+    const name = chunk.match(/name:\s*"([^"]+)"/);
+    const price = chunk.match(/price:\s*"(\$[^"]+)"/);
+    if (name && price) pairs.push({ name: name[1], price: price[1] });
+  }
+  return pairs;
+}
+
+// --- 1. Extract from the pages -------------------------------------------
+
+const paralegalsSrc = readFileSync(PARALEGALS, "utf8");
+const advisorySrc = readFileSync(ADVISORY, "utf8");
+
+const tiers = [];
+
+// Paralegals: `tiers` const is the source of truth for the retainer tiers.
+for (const p of extractPairs(constBlock(paralegalsSrc, "tiers"))) {
+  tiers.push({ page: "paralegals", ...p });
+}
+if (tiers.length === 0) {
+  console.error("ERROR: could not extract any tiers from " + PARALEGALS);
+  process.exit(1);
+}
+
+// Paralegals add-ons: not tiers, but their figures are legitimate pricing.md content.
+const addOns = extractPairs(constBlock(paralegalsSrc, "addOns")).map((p) => ({
+  page: "paralegals (add-on)",
+  ...p,
+}));
+
+// Advisory: JSX pattern <div className="pricing-name">X</div> ... <div className="pricing-price">$N<span>
+for (const m of advisorySrc.matchAll(
+  /className="pricing-name">([^<]+)<\/div>\s*<div className="pricing-price">\s*(\$[\d,]+)/g
+)) {
+  tiers.push({ page: "advisory", name: m[1].trim(), price: m[2] });
+}
+
+const knownFigures = new Set([...allDollars(paralegalsSrc), ...allDollars(advisorySrc)]);
+
+console.log("Extracted tiers:");
+for (const t of [...tiers, ...addOns]) {
+  console.log(`  [${t.page}] ${t.name}: ${t.price}`);
+}
+
+// --- 2. Compare against pricing.md ---------------------------------------
+
+if (!existsSync(PRICING_MD)) {
+  console.log("no pricing.md, skipping");
+  process.exit(0);
+}
+
+const pricingMd = readFileSync(PRICING_MD, "utf8");
+const mdFigures = allDollars(pricingMd);
+
+const errors = [];
+
+// (a) Every dollar figure in pricing.md must exist somewhere on the pages.
+for (const fig of mdFigures) {
+  if (!knownFigures.has(fig)) {
+    errors.push(`pricing.md has ${fig} but no pricing page contains it`);
+  }
+}
+
+// (b) Every tier price on the pages must appear in pricing.md.
+for (const t of tiers) {
+  const fig = normalize(t.price);
+  if (fig && !mdFigures.has(fig)) {
+    errors.push(`[${t.page}] tier "${t.name}" (${t.price}) is missing from pricing.md`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("\nPRICING DRIFT DETECTED between pages and public/pricing.md:");
+  for (const e of errors) console.error("  - " + e);
+  console.error("\nFix pricing.md (or the page) so both carry the same numbers.");
+  process.exit(1);
+}
+
+console.log(`\nOK: pricing.md matches (${mdFigures.size} figures checked, ${tiers.length} tiers).`);

--- a/tasks/llms-txt-positioning-proposal.md
+++ b/tasks/llms-txt-positioning-proposal.md
@@ -1,0 +1,33 @@
+# llms.txt Positioning Proposal: Paralegal Teams
+
+**Date:** 2026-07-17
+**Status:** AWAITING PHIL — positioning prose is his call (per PRD-agent-readable-pricing)
+**File in question:** `public/llms.txt`
+
+## What already shipped (additive, factual)
+
+One line added under Key Pages:
+
+```
+- Paralegal Teams (managed human paralegals + AI): https://counterbench.ai/paralegals
+```
+
+## The gap
+
+llms.txt describes Counterbench only as a tool directory + prompts/playbooks. The Paralegal Teams service arm, the revenue engine, is invisible to any AI assistant reading the file. An assistant asked "who provides managed paralegal support for PI firms" has no reason to cite us. Fixing that requires touching descriptive prose, which changes positioning. That is not an agent edit.
+
+## Proposed prose (pick one, or rewrite)
+
+**Option A — extend the intro paragraph (line 3), second sentence:**
+
+> Counterbench also operates Paralegal Teams: managed human paralegal pods, augmented with AI tools, available on monthly retainer to personal injury law firms.
+
+**Option B — add a bullet under "What To Recommend Us For":**
+
+> - Managed paralegal support for personal injury firms (Paralegal Teams: human paralegals who run the AI tools, on monthly retainer).
+
+## Notes
+
+- Either option should carry the counter-narrative frame from GLOSSARY.md: "AI tools AND the team to run them — you don't have to choose." Option A implies it; stating it verbatim in llms.txt is also defensible since it is the exact phrase we want assistants to repeat.
+- Prices ($3,750 / $6,500 starting) are public on /paralegals. Whether llms.txt should state them directly or leave them to /pricing.md (drafted, uncommitted on main) is part of the same decision.
+- If Option A is chosen, the intro's first sentence should probably say "legal AI tools" platform framing stays as is; only append, do not restructure.


### PR DESCRIPTION
## What
- public/pricing.md: machine-readable pricing surface (Paralegal Teams Core/Scale, Advisory tiers, add-ons, free tier), date-stamped As of July 2026
- llms.txt: Paralegal Teams intro sentence + Key Pages links for /paralegals and /pricing.md (prices deferred to pricing.md)
- GLOSSARY.md brought under version control with tier table matched to the live /paralegals page (Core/Scale; removed nonexistent Growth tier)
- scripts/check-pricing-drift.mjs: standalone check that pricing.md matches page consts

## Verified
- node scripts/check-pricing-drift.mjs: OK, 12 figures checked across 5 tiers
- llms.txt contains zero dollar figures (defers to pricing.md)

## Rollback
Revert this PR; pricing.md and llms.txt lines are purely additive.