### PR TITLE
feat(seo): Conflict Check Blind Spot Audit free tool

### DIFF
--- a/__tests__/conflict-check-audit.test.ts
+++ b/__tests__/conflict-check-audit.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests: Conflict Check Blind Spot Audit scoring.
+ *
+ * Locks the pure logic in lib/conflict-check-audit.ts:
+ *   - tier boundaries (every threshold, both sides)
+ *   - blind-spot triggers (each question fires exactly at/below its trigger)
+ *   - finding ordering (cheapest fix first, structural last)
+ *   - completeness flag
+ *   - data integrity of the question set
+ *
+ * Run: npx vitest run __tests__/conflict-check-audit.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  QUESTIONS,
+  TIERS,
+  MAX_SCORE,
+  scoreAudit,
+  tierForScore,
+  rulesFromFindings,
+  type AuditAnswers,
+  type OptionValue,
+} from "@/lib/conflict-check-audit";
+
+function answerAll(value: OptionValue): AuditAnswers {
+  return Object.fromEntries(QUESTIONS.map((q) => [q.id, value]));
+}
+
+describe("data integrity", () => {
+  it("has exactly 8 questions and MAX_SCORE 24", () => {
+    expect(QUESTIONS).toHaveLength(8);
+    expect(MAX_SCORE).toBe(24);
+  });
+
+  it("every question has 4 options scoring 0,1,2,3", () => {
+    for (const q of QUESTIONS) {
+      expect(q.options.map((o) => o.value)).toEqual([0, 1, 2, 3]);
+    }
+  });
+
+  it("question ids and keys are unique", () => {
+    expect(new Set(QUESTIONS.map((q) => q.id)).size).toBe(8);
+    expect(new Set(QUESTIONS.map((q) => q.key)).size).toBe(8);
+  });
+
+  it("tiers tile 0–24 with no gaps or overlaps", () => {
+    const sorted = [...TIERS].sort((a, b) => a.min - b.min);
+    expect(sorted[0]!.min).toBe(0);
+    expect(sorted[sorted.length - 1]!.max).toBe(24);
+    for (let i = 1; i < sorted.length; i++) {
+      expect(sorted[i]!.min).toBe(sorted[i - 1]!.max + 1);
+    }
+  });
+});
+
+describe("tierForScore boundaries", () => {
+  const cases: [number, string][] = [
+    [0, "undocumented"],
+    [5, "undocumented"],
+    [6, "reactive"],
+    [11, "reactive"],
+    [12, "person_dependent"],
+    [18, "person_dependent"],
+    [19, "documented"],
+    [24, "documented"],
+  ];
+  it.each(cases)("score %i => %s", (score, key) => {
+    expect(tierForScore(score).key).toBe(key);
+  });
+});
+
+describe("scoreAudit totals", () => {
+  it("all 3s = 24, Documented, no findings", () => {
+    const r = scoreAudit(answerAll(3));
+    expect(r.score).toBe(24);
+    expect(r.tier.key).toBe("documented");
+    expect(r.findings).toHaveLength(0);
+    expect(r.complete).toBe(true);
+  });
+
+  it("all 0s = 0, Undocumented, a finding for every question", () => {
+    const r = scoreAudit(answerAll(0));
+    expect(r.score).toBe(0);
+    expect(r.tier.key).toBe("undocumented");
+    expect(r.findings).toHaveLength(8);
+  });
+
+  it("all 2s = 16, Person-dependent, no findings (trigger is <=1)", () => {
+    const r = scoreAudit(answerAll(2));
+    expect(r.score).toBe(16);
+    expect(r.tier.key).toBe("person_dependent");
+    expect(r.findings).toHaveLength(0);
+  });
+});
+
+describe("blind-spot triggers", () => {
+  it("each question fires at value 1 and below, not at 2", () => {
+    for (const q of QUESTIONS) {
+      // trigger is 1 for all current questions; assert against the data, not a constant
+      const at = q.finding.triggerAtOrBelow;
+      const fires = scoreAudit({ [q.id]: at });
+      expect(fires.findings.some((f) => f.questionId === q.id)).toBe(true);
+
+      const above = (at + 1) as OptionValue;
+      if (above <= 3) {
+        const clears = scoreAudit({ [q.id]: above });
+        expect(clears.findings.some((f) => f.questionId === q.id)).toBe(false);
+      }
+    }
+  });
+
+  it("q7 single-point-of-failure finding carries no rule (management gap)", () => {
+    const r = scoreAudit({ q7: 1 });
+    const f = r.findings.find((x) => x.questionId === "q7");
+    expect(f).toBeDefined();
+    expect(f!.rules).toBeNull();
+  });
+
+  it("q5 lateral finding maps to Rule 1.10", () => {
+    const r = scoreAudit({ q5: 0 });
+    const f = r.findings.find((x) => x.questionId === "q5");
+    expect(f!.rules).toContain("1.10");
+  });
+});
+
+describe("finding ordering", () => {
+  it("cheapest fix first, structural (null effort) last", () => {
+    const r = scoreAudit(answerAll(0));
+    const efforts = r.findings.map((f) => f.effortMinutes ?? Number.POSITIVE_INFINITY);
+    const sorted = [...efforts].sort((a, b) => a - b);
+    expect(efforts).toEqual(sorted);
+    // the three structural findings (q3, q5, q7) sink to the end
+    const tail = r.findings.slice(-3).map((f) => f.questionId).sort();
+    expect(tail).toEqual(["q3", "q5", "q7"]);
+  });
+});
+
+describe("completeness", () => {
+  it("is false until all eight are answered", () => {
+    const partial: AuditAnswers = { q1: 3, q2: 3, q3: 3 };
+    expect(scoreAudit(partial).complete).toBe(false);
+  });
+
+  it("ignores unanswered questions in the running total", () => {
+    const r = scoreAudit({ q1: 3, q2: 3 });
+    expect(r.score).toBe(6);
+    expect(r.complete).toBe(false);
+  });
+});
+
+describe("rulesFromFindings", () => {
+  it("returns a sorted distinct set", () => {
+    const r = scoreAudit(answerAll(0));
+    const rules = rulesFromFindings(r.findings);
+    expect(rules).toEqual([...new Set(rules)].sort());
+    expect(rules).toContain("1.9");
+    expect(rules).toContain("1.18");
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -894,3 +894,124 @@ html[data-theme="light"] .ws-earlybird {
   line-height: 1.7;
   color: var(--muted);
 }
+
+/* ---------------------------------------------------------------------------
+   Conflict Check Blind Spot Audit (/tools/conflict-check-audit)
+   Layout only; colours inherit from the design tokens above.
+--------------------------------------------------------------------------- */
+.cca {
+  margin-top: 2rem;
+}
+.cca-questions,
+.cca-findings {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: cca;
+}
+.cca-q-title {
+  margin: 0.5rem 0 1rem;
+  font-family: var(--serif);
+  font-size: 1.2rem;
+  line-height: 1.35;
+}
+.cca-rule,
+.cca-effort {
+  color: var(--muted);
+  font-weight: 400;
+}
+.cca-options {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.cca-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--input-bg);
+  cursor: pointer;
+  transition: border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+.cca-option:hover {
+  background: var(--hover-bg);
+}
+.cca-option:has(input:checked) {
+  border-color: var(--teal);
+  background: var(--hover-bg);
+}
+.cca-option:has(input:focus-visible) {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+.cca-option input {
+  margin-top: 0.15rem;
+  flex: 0 0 auto;
+}
+.cca-actions,
+.cca-result-actions,
+.cca-benchmark-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+.cca-progress {
+  font-size: 0.9rem;
+}
+.cca-score {
+  font-family: var(--serif);
+  font-size: 2.6rem;
+  line-height: 1;
+  margin: 0.25rem 0;
+}
+.cca-tier {
+  margin: 0.25rem 0 0.5rem;
+}
+.cca-scenario {
+  margin: 0.5rem 0;
+}
+.cca-fix {
+  margin: 0.5rem 0 0;
+}
+.cca-benchmark-fields {
+  align-items: flex-end;
+}
+.cca-benchmark-fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+.cca-benchmark-fields select,
+.cca-benchmark-fields input {
+  padding: 0.5rem 0.65rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--input-bg);
+  color: var(--fg);
+  min-width: 8rem;
+}
+.cca-disclaimer {
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+@media print {
+  .cca-form,
+  .cca-cta,
+  .cca-benchmark,
+  .cca-result-actions,
+  header,
+  nav,
+  footer {
+    display: none !important;
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -17,6 +17,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/tools/compare"), lastModified: now, changeFrequency: "monthly", priority: 0.5 },
     { url: absoluteUrl("/tools/source-finder"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/contract-qa-planner"), lastModified: now, changeFrequency: "weekly", priority: 0.74 },
+    { url: absoluteUrl("/tools/conflict-check-audit"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/guides"), lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: absoluteUrl("/about"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/contact"), lastModified: now, changeFrequency: "monthly", priority: 0.7 },

--- a/app/tools/conflict-check-audit/page.tsx
+++ b/app/tools/conflict-check-audit/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from "next";
+import { ConflictCheckAudit } from "@/components/ConflictCheckAudit";
+import { absoluteUrl, faqPageJsonLd } from "@/lib/seo";
+import { QUESTIONS, TIERS, AUDIT_FAQ, MAX_SCORE, LAST_VERIFIED } from "@/lib/conflict-check-audit";
+
+const TITLE = "Conflict Check Blind Spot Audit";
+const DESCRIPTION =
+  "A free eight-question audit of how your law firm actually runs conflict checks. Get a risk tier plus a named list of the blind spots most likely to produce a disqualification motion. Under three minutes, no signup.";
+const URL = absoluteUrl("/tools/conflict-check-audit");
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: URL },
+  openGraph: {
+    title: `${TITLE} | Counterbench.AI`,
+    description: DESCRIPTION,
+    url: URL,
+    type: "website",
+  },
+};
+
+function softwareApplicationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: TITLE,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    description: DESCRIPTION,
+    url: URL,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    isAccessibleForFree: true,
+  };
+}
+
+export default function ConflictCheckAuditPage() {
+  return (
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd()) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageJsonLd(AUDIT_FAQ)) }}
+      />
+
+      <section className="section" style={{ paddingTop: 108, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label">Free tool</div>
+          <h1 className="max-w-900">Does your conflict check actually catch conflicts?</h1>
+
+          {/* First 40 words: plain-text answer to the target query, above the tool,
+              for the featured snippet and LLM extraction. */}
+          <p className="max-w-820 mt-4" style={{ fontSize: "1.125rem" }}>
+            A conflict check is the process a law firm runs before taking a matter to confirm the representation does not
+            conflict with duties owed to a current, former, or prospective client. This audit measures how reliably your
+            firm&apos;s process catches those conflicts, and names the gaps most likely to cost you.
+          </p>
+
+          <ConflictCheckAudit />
+        </div>
+      </section>
+
+      {/* ---- Server-rendered reference. Guarantees crawlers and LLMs see the
+           full instrument — every failure mode, rule, and tier — without
+           running the form. ---- */}
+      <section className="section" style={{ paddingTop: 0, paddingBottom: "4rem" }}>
+        <div className="container">
+          <h2>What this audit checks</h2>
+          <p className="max-w-820 text-muted">
+            Eight questions, each testing a documented way conflict checks fail at small firms. Where a rule applies, it
+            references the ABA Model Rules of Professional Conduct.
+          </p>
+          <ul className="max-w-820 mt-4">
+            {QUESTIONS.map((q) => (
+              <li key={q.id} style={{ marginBottom: "0.75rem" }}>
+                <strong>{q.failureMode}</strong>
+                {q.rules ? <span className="text-muted"> — Model Rule {q.rules.join(", ")}</span> : null}
+                <br />
+                <span className="text-muted">{q.question}</span>
+              </li>
+            ))}
+          </ul>
+
+          <h2 className="mt-5">How the score reads</h2>
+          <ul className="max-w-820 mt-4">
+            {TIERS.map((t) => (
+              <li key={t.key} style={{ marginBottom: "0.5rem" }}>
+                <strong>
+                  {t.label} ({t.min}–{t.max} of {MAX_SCORE})
+                </strong>{" "}
+                — <span className="text-muted">{t.meaning}</span>
+              </li>
+            ))}
+          </ul>
+
+          <h2 className="mt-5">Questions</h2>
+          <dl className="max-w-820 mt-4">
+            {AUDIT_FAQ.map((f) => (
+              <div key={f.q} style={{ marginBottom: "1rem" }}>
+                <dt>
+                  <strong>{f.q}</strong>
+                </dt>
+                <dd className="text-muted" style={{ margin: 0 }}>
+                  {f.a}
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <p className="text-muted mt-5" style={{ fontSize: "0.9rem" }}>
+            Not legal advice. This tool audits process, never a specific conflict, and never tells a firm whether it may
+            take a matter. Rule citations reference the ABA Model Rules of Professional Conduct (last verified{" "}
+            {LAST_VERIFIED}); your state&apos;s rules govern and may differ.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/ConflictCheckAudit.tsx
+++ b/components/ConflictCheckAudit.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  QUESTIONS,
+  MAX_SCORE,
+  scoreAudit,
+  rulesFromFindings,
+  LAST_VERIFIED,
+  type AuditAnswers,
+  type OptionValue,
+} from "@/lib/conflict-check-audit";
+const TOOL_SLUG = "conflict-check-audit";
+
+// Local dataLayer helpers. Event shapes mirror lib/analytics.ts (tool_view,
+// tool_click_cta) so GTM/GA sees identical events; kept inline here so this
+// tool has no cross-module dependency to ship. Fold into lib/analytics.ts if
+// that module is later extended.
+function pushEvent(event: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(event);
+}
+function trackToolView(toolSlug: string): void {
+  pushEvent({ event: "tool_view", tool_slug: toolSlug });
+}
+function trackToolCTA(toolSlug: string, destination: string): void {
+  pushEvent({ event: "tool_click_cta", tool_slug: toolSlug, destination });
+}
+
+type FirmSize = "solo" | "2-5" | "6-10" | "11-25" | "25+";
+type Benchmark = { size: FirmSize | ""; state: string; practice: string };
+
+function effortLabel(minutes: number | null): string {
+  if (minutes === null) return "Structural fix";
+  if (minutes <= 30) return `~${minutes} min`;
+  if (minutes < 60) return `~${minutes} min`;
+  return "~1 hour";
+}
+
+export function ConflictCheckAudit() {
+  const [answers, setAnswers] = useState<AuditAnswers>({});
+  const [submitted, setSubmitted] = useState(false);
+  const [benchmark, setBenchmark] = useState<Benchmark>({ size: "", state: "", practice: "" });
+  const [benchmarkSent, setBenchmarkSent] = useState(false);
+
+  useEffect(() => {
+    trackToolView(TOOL_SLUG);
+  }, []);
+
+  const result = useMemo(() => scoreAudit(answers), [answers]);
+  const answeredCount = Object.keys(answers).length;
+
+  function choose(qid: string, value: OptionValue) {
+    setAnswers((prev) => ({ ...prev, [qid]: value }));
+  }
+
+  function onSubmit() {
+    if (!result.complete) return;
+    setSubmitted(true);
+    // Scroll the result into view for keyboard + mobile users.
+    requestAnimationFrame(() => {
+      document.getElementById("audit-result")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }
+
+  function reset() {
+    setAnswers({});
+    setSubmitted(false);
+    setBenchmark({ size: "", state: "", practice: "" });
+    setBenchmarkSent(false);
+  }
+
+  function ctaClick() {
+    trackToolCTA(TOOL_SLUG, "/paralegals");
+  }
+
+  function saveBenchmark() {
+    // v1: no backend. Record the anonymous row into the dataLayer only; a real
+    // sink can consume the event later without changing this component.
+    pushEvent({
+      event: "conflict_audit_benchmark",
+      tool_slug: TOOL_SLUG,
+      score: result.score,
+      tier: result.tier.key,
+      firm_size: benchmark.size || "unspecified",
+      state: benchmark.state || "unspecified",
+      practice_area: benchmark.practice || "unspecified",
+    });
+    setBenchmarkSent(true);
+  }
+
+  const rules = rulesFromFindings(result.findings);
+
+  return (
+    <div className="cca">
+      {/* ---- Questions ---- */}
+      {!submitted && (
+        <form
+          className="cca-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            onSubmit();
+          }}
+        >
+          <ol className="cca-questions">
+            {QUESTIONS.map((q, i) => (
+              <li key={q.id} className="card mt-4 cca-q">
+                <div className="label">
+                  Question {i + 1} of {QUESTIONS.length}
+                  {q.rules ? <span className="cca-rule"> · Model Rule {q.rules.join(", ")}</span> : null}
+                </div>
+                <h3 className="cca-q-title">{q.question}</h3>
+                <fieldset className="cca-options">
+                  <legend className="sr-only">{q.question}</legend>
+                  {q.options.map((opt) => {
+                    const id = `${q.id}-${opt.value}`;
+                    return (
+                      <label key={id} htmlFor={id} className="cca-option">
+                        <input
+                          type="radio"
+                          id={id}
+                          name={q.id}
+                          value={opt.value}
+                          checked={answers[q.id] === opt.value}
+                          onChange={() => choose(q.id, opt.value)}
+                        />
+                        <span>{opt.label}</span>
+                      </label>
+                    );
+                  })}
+                </fieldset>
+              </li>
+            ))}
+          </ol>
+
+          <div className="cca-actions mt-5">
+            <button type="submit" className="btn btn--primary" disabled={!result.complete}>
+              {result.complete ? "See your blind spots" : `Answer all ${QUESTIONS.length} questions`}
+            </button>
+            <span className="text-muted cca-progress">
+              {answeredCount}/{QUESTIONS.length} answered
+            </span>
+          </div>
+        </form>
+      )}
+
+      {/* ---- Result ---- */}
+      {submitted && (
+        <div id="audit-result" className="cca-result">
+          <div className="card cca-score-card">
+            <div className="label">Your result</div>
+            <div className="cca-score">
+              <strong>{result.score}</strong>
+              <span className="text-muted"> / {MAX_SCORE}</span>
+            </div>
+            <h2 className="cca-tier">{result.tier.label}</h2>
+            <p className="cca-tier-meaning">{result.tier.meaning}</p>
+          </div>
+
+          {result.findings.length > 0 ? (
+            <>
+              <h3 className="mt-5">
+                {result.findings.length} blind spot{result.findings.length === 1 ? "" : "s"}, cheapest fix first
+              </h3>
+              <ol className="cca-findings">
+                {result.findings.map((f) => (
+                  <li key={f.questionId} className="card mt-4 cca-finding">
+                    <div className="label">
+                      {f.failureMode}
+                      {f.rules ? <span className="cca-rule"> · Model Rule {f.rules.join(", ")}</span> : null}
+                      <span className="cca-effort"> · {effortLabel(f.effortMinutes)}</span>
+                    </div>
+                    <p className="cca-scenario">{f.scenario}</p>
+                    <p className="cca-fix">
+                      <strong>Fix:</strong> {f.fix}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+            </>
+          ) : (
+            <p className="mt-5">
+              No blind spots flagged. Your process covers the eight failure modes this audit tests. Keep the written
+              version current as the firm grows.
+            </p>
+          )}
+
+          {/* CTA — honest, tier-aware, vendor-neutral */}
+          <div className="card cca-cta mt-5">
+            <p>
+              Most of these gaps come down to the same thing: the process lives in one person&apos;s head instead of on
+              paper. That is exactly the work a paralegal team takes off your plate — running checks the same way every
+              time, and keeping the record that proves it.
+            </p>
+            <Link href="/paralegals" className="btn btn--primary" onClick={ctaClick}>
+              See how Paralegal Teams works
+            </Link>
+          </div>
+
+          {/* Benchmark ask — post-value, three fields, no email */}
+          {!benchmarkSent ? (
+            <div className="card cca-benchmark mt-5">
+              <div className="label">Optional · anonymous</div>
+              <p>See how firms like yours compare. Three fields, no email, not tied to you.</p>
+              <div className="cca-benchmark-fields">
+                <label>
+                  Firm size
+                  <select
+                    value={benchmark.size}
+                    onChange={(e) => setBenchmark((b) => ({ ...b, size: e.target.value as FirmSize }))}
+                  >
+                    <option value="">Select…</option>
+                    <option value="solo">Solo</option>
+                    <option value="2-5">2–5</option>
+                    <option value="6-10">6–10</option>
+                    <option value="11-25">11–25</option>
+                    <option value="25+">25+</option>
+                  </select>
+                </label>
+                <label>
+                  State
+                  <input
+                    type="text"
+                    maxLength={2}
+                    placeholder="e.g. CA"
+                    value={benchmark.state}
+                    onChange={(e) => setBenchmark((b) => ({ ...b, state: e.target.value.toUpperCase() }))}
+                  />
+                </label>
+                <label>
+                  Practice area
+                  <input
+                    type="text"
+                    placeholder="e.g. Personal injury"
+                    value={benchmark.practice}
+                    onChange={(e) => setBenchmark((b) => ({ ...b, practice: e.target.value }))}
+                  />
+                </label>
+              </div>
+              <button type="button" className="btn btn--secondary btn--sm mt-4" onClick={saveBenchmark}>
+                Add to the benchmark
+              </button>
+            </div>
+          ) : (
+            <p className="text-muted mt-5">Thanks — added anonymously.</p>
+          )}
+
+          <div className="cca-result-actions mt-5">
+            <button type="button" className="btn btn--secondary btn--sm" onClick={() => window.print()}>
+              Print / save as PDF
+            </button>
+            <button type="button" className="btn btn--secondary btn--sm" onClick={reset}>
+              Start over
+            </button>
+          </div>
+
+          <p className="text-muted cca-disclaimer mt-5">
+            This audits your process, not any specific conflict, and is not legal advice. Rule citations reference the
+            ABA Model Rules of Professional Conduct (last verified {LAST_VERIFIED}); your state&apos;s rules govern and
+            may differ. {rules.length > 0 ? `Rules referenced in your result: ${rules.join(", ")}.` : ""}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/conflict-check-audit.ts
+++ b/lib/conflict-check-audit.ts
@@ -1,0 +1,348 @@
+/**
+ * Conflict Check Blind Spot Audit — data + scoring.
+ *
+ * Pure data and pure functions only. No React, no DOM, no side effects, so the
+ * whole module is unit-testable and can be imported by the server component to
+ * render every question, answer, tier and finding into the initial HTML (AEO
+ * requirement: crawlers and LLMs must see the full content without running the
+ * form).
+ *
+ * The tool audits a firm's conflict-checking *process*. It never evaluates a
+ * specific conflict and never tells a firm whether it may take a matter. Rule
+ * citations reference the ABA Model Rules of Professional Conduct and must be
+ * verified against current text; state rules vary. See LAST_VERIFIED.
+ */
+
+export const LAST_VERIFIED = "2026-07-24";
+
+export type OptionValue = 0 | 1 | 2 | 3;
+
+export interface AuditOption {
+  /** Points toward the 0–24 total. Higher = more institutionalised. */
+  value: OptionValue;
+  label: string;
+}
+
+export interface AuditQuestion {
+  id: string;
+  /** Short label for compact UI + analytics. */
+  key: string;
+  question: string;
+  /** The documented failure mode this question tests. */
+  failureMode: string;
+  /** ABA Model Rule(s) this maps to, or null where it is a management gap. */
+  rules: string[] | null;
+  options: AuditOption[];
+  /**
+   * Blind-spot finding shown when the chosen answer scores at or below
+   * `triggerAtOrBelow`. `scenario` names the concrete failure; `fix` is the
+   * ranked remediation. `effortMinutes` orders fixes cheapest-first.
+   */
+  finding: {
+    triggerAtOrBelow: OptionValue;
+    scenario: string;
+    fix: string;
+    effortMinutes: number | null; // null = structural, not a quick fix
+  };
+}
+
+export const QUESTIONS: AuditQuestion[] = [
+  {
+    id: "q1",
+    key: "timing",
+    question: "At what point in intake is a conflict check actually run?",
+    failureMode: "Conflict discovered after work has already begun",
+    rules: ["1.7"],
+    options: [
+      { value: 0, label: "It varies, or only when someone remembers" },
+      { value: 1, label: "At the engagement letter" },
+      { value: 2, label: "After the intake call, before any work" },
+      { value: 3, label: "Before the first substantive intake conversation" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "A conflict surfaces after you have taken confidences or started work, which is the most expensive point to find it — you may have to withdraw and you have already learned things you cannot un-learn.",
+      fix: "Move the check to a hard gate before the first substantive intake conversation. No matter opens without it.",
+      effortMinutes: 30,
+    },
+  },
+  {
+    id: "q2",
+    key: "parties",
+    question: "Which parties get searched in a check?",
+    failureMode: "Corporate families and related entities missed",
+    rules: ["1.7", "1.13"],
+    options: [
+      { value: 0, label: "The named client only" },
+      { value: 1, label: "Client plus the obvious adverse party" },
+      { value: 2, label: "Client, adverse parties, and related entities / corporate families" },
+      { value: 3, label: "All of the above plus witnesses, experts, and co-counsel" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "You clear the named party but miss the parent, subsidiary, or affiliate you are already adverse to. The organization is the client under Rule 1.13, and the conflict is real even though the names do not match.",
+      fix: "Add related entities and corporate families to the standard search scope. Capture them on the intake form so the search has something to run against.",
+      effortMinutes: 60,
+    },
+  },
+  {
+    id: "q3",
+    key: "former_clients",
+    question: "Are closed and former-client matters searched?",
+    failureMode: "Duties to former clients under-checked",
+    rules: ["1.9"],
+    options: [
+      { value: 0, label: "No, only open matters" },
+      { value: 1, label: "Only if someone remembers the prior representation" },
+      { value: 2, label: "Yes, going back a fixed number of years" },
+      { value: 3, label: "Yes, the full closed-matter history" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "You take a matter adverse to a former client in a substantially related matter without catching it. Rule 1.9 duties survive the end of the representation; institutional memory does not.",
+      fix: "Include closed matters in every search. If the system cannot reach them, that is the gap to close before the next intake.",
+      effortMinutes: null,
+    },
+  },
+  {
+    id: "q4",
+    key: "prospective_clients",
+    question: "Are non-engaged consultations recorded and searched?",
+    failureMode: "Prospective-client confidences ignored",
+    rules: ["1.18"],
+    options: [
+      { value: 0, label: "No, we only record clients we sign" },
+      { value: 1, label: "Sometimes, informally" },
+      { value: 2, label: "Yes, most consults are logged" },
+      { value: 3, label: "Yes, every consult is logged and searchable" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "Someone who consulted you and shared confidences, then never engaged, is invisible to your check. Rule 1.18 can still disqualify you from the other side of that matter.",
+      fix: "Log every consultation — name, adverse parties, general subject — even the ones that never become clients. It is the only record that catches this.",
+      effortMinutes: 30,
+    },
+  },
+  {
+    id: "q5",
+    key: "lateral_hires",
+    question: "When someone joins, is their prior client list run against your book?",
+    failureMode: "Imputed disqualification from a lateral's history",
+    rules: ["1.10"],
+    options: [
+      { value: 0, label: "No" },
+      { value: 1, label: "Informally, if it comes up" },
+      { value: 2, label: "Yes, for attorneys" },
+      { value: 3, label: "Yes, systematically, for every hire including staff" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "A new attorney or paralegal carries a conflict from a prior firm and it is imputed to yours under Rule 1.10. You find out when the other side moves to disqualify — after the person has already touched the file.",
+      fix: "Run every incoming hire's prior client list against your open and closed matters before their first day, and set up a screen where one is needed. Paralegals and assistants count.",
+      effortMinutes: null,
+    },
+  },
+  {
+    id: "q6",
+    key: "system_of_record",
+    question: "Where do conflict-check results live?",
+    failureMode: "No durable system of record",
+    rules: null,
+    options: [
+      { value: 0, label: "Nowhere durable — it is done and forgotten" },
+      { value: 1, label: "Email or a paper file" },
+      { value: 2, label: "A spreadsheet" },
+      { value: 3, label: "Conflict-check or practice-management software" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "You cannot show, months later, that a check was run or what it returned. When a conflict is alleged, the absence of a record is treated as the absence of a check.",
+      fix: "Keep a dated, searchable record of every check and its result — who ran it, what was searched, what it returned. A shared spreadsheet is a real improvement over email; software is better.",
+      effortMinutes: 60,
+    },
+  },
+  {
+    id: "q7",
+    key: "ownership",
+    question: "Who can run a complete conflict check today, without help?",
+    failureMode: "Single point of failure",
+    rules: null,
+    options: [
+      { value: 0, label: "It is unclear / no one is sure" },
+      { value: 1, label: "Exactly one person" },
+      { value: 2, label: "Two or more people" },
+      { value: 3, label: "Any trained staff member, against a written procedure" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "Your conflict process lives in one person's head. When they are out, on leave, or gone, the firm is either running unchecked intakes or stalled. This is the same institutional-knowledge risk that shows up everywhere else in a small firm — here it has an ethics rule attached.",
+      fix: "Write the procedure down so a second trained person can run a complete check against it. The written version is the asset; the person is the risk.",
+      effortMinutes: null,
+    },
+  },
+  {
+    id: "q8",
+    key: "waivers",
+    question: "Are conflict waivers and ethical walls tracked with scope and expiry?",
+    failureMode: "Waiver conditions lost or exceeded",
+    rules: ["1.7(b)"],
+    options: [
+      { value: 0, label: "Not tracked" },
+      { value: 1, label: "Verbally, or 'we'd remember'" },
+      { value: 2, label: "In the matter file" },
+      { value: 3, label: "Tracked in a system with scope and expiry" },
+    ],
+    finding: {
+      triggerAtOrBelow: 1,
+      scenario:
+        "A waiver's scope is exceeded, or a screen quietly lapses, because no one is tracking its terms. Rule 1.7(b) requires informed consent confirmed in writing — an untracked waiver is hard to prove and easy to outgrow.",
+      fix: "Record every waiver and screen with its scope and any expiry, in writing, where the next person can find it. A verbal 'we'd remember' is not a defensible record.",
+      effortMinutes: 45,
+    },
+  },
+];
+
+export const MAX_SCORE = QUESTIONS.length * 3; // 24
+
+export interface Tier {
+  key: "documented" | "person_dependent" | "reactive" | "undocumented";
+  label: string;
+  min: number;
+  max: number;
+  meaning: string;
+}
+
+export const TIERS: Tier[] = [
+  {
+    key: "documented",
+    label: "Documented",
+    min: 19,
+    max: 24,
+    meaning:
+      "Your conflict process survives the departure of any one person. Keep it current as the firm grows.",
+  },
+  {
+    key: "person_dependent",
+    label: "Person-dependent",
+    min: 12,
+    max: 18,
+    meaning:
+      "It works today, but it leans on specific people and specific memory. Turnover or a volume spike is where it breaks.",
+  },
+  {
+    key: "reactive",
+    label: "Reactive",
+    min: 6,
+    max: 11,
+    meaning:
+      "You catch the obvious conflict and miss the imputed one. The gaps are in former clients, related entities, and laterals — exactly where disqualification motions come from.",
+  },
+  {
+    key: "undocumented",
+    label: "Undocumented",
+    min: 0,
+    max: 5,
+    meaning:
+      "The process is running on memory. The next conflict is a question of when, not whether, and you will find out the expensive way.",
+  },
+];
+
+export interface AuditAnswers {
+  [questionId: string]: OptionValue;
+}
+
+export interface AuditFinding {
+  questionId: string;
+  key: string;
+  failureMode: string;
+  rules: string[] | null;
+  scenario: string;
+  fix: string;
+  effortMinutes: number | null;
+}
+
+export interface AuditResult {
+  score: number;
+  maxScore: number;
+  tier: Tier;
+  /** Findings for every answer at or below its trigger, cheapest-fix first. */
+  findings: AuditFinding[];
+  /** True when all eight questions are answered. */
+  complete: boolean;
+}
+
+// Undocumented is the floor tier; used as a defensive clamp for scores that
+// somehow fall outside 0–24 (impossible with the fixed 0–3 option set).
+const FLOOR_TIER: Tier = TIERS[TIERS.length - 1]!;
+
+export function tierForScore(score: number): Tier {
+  const t = TIERS.find((x) => score >= x.min && score <= x.max);
+  return t ?? FLOOR_TIER;
+}
+
+export function scoreAudit(answers: AuditAnswers): AuditResult {
+  let score = 0;
+  const findings: AuditFinding[] = [];
+
+  for (const q of QUESTIONS) {
+    const a = answers[q.id];
+    if (a === undefined) continue;
+    score += a;
+    if (a <= q.finding.triggerAtOrBelow) {
+      findings.push({
+        questionId: q.id,
+        key: q.key,
+        failureMode: q.failureMode,
+        rules: q.rules,
+        scenario: q.finding.scenario,
+        fix: q.finding.fix,
+        effortMinutes: q.finding.effortMinutes,
+      });
+    }
+  }
+
+  // Cheapest, most-actionable fixes first; structural (null) fixes last.
+  findings.sort((a, b) => {
+    const ea = a.effortMinutes ?? Number.POSITIVE_INFINITY;
+    const eb = b.effortMinutes ?? Number.POSITIVE_INFINITY;
+    return ea - eb;
+  });
+
+  const complete = QUESTIONS.every((q) => answers[q.id] !== undefined);
+
+  return { score, maxScore: MAX_SCORE, tier: tierForScore(score), findings, complete };
+}
+
+/** Distinct set of rules referenced by the current findings, for the summary. */
+export function rulesFromFindings(findings: AuditFinding[]): string[] {
+  const set = new Set<string>();
+  for (const f of findings) (f.rules ?? []).forEach((r) => set.add(r));
+  return Array.from(set).sort();
+}
+
+/** FAQ used both on-page and in FAQPage JSON-LD. */
+export const AUDIT_FAQ: { q: string; a: string }[] = [
+  {
+    q: "What is a law firm conflict check?",
+    a: "A conflict check is the process a law firm runs before taking on a matter to confirm that representing the new client would not conflict with duties owed to a current client, a former client, or a prospective client. It searches the parties involved against the firm's current and past matters. This audit measures how reliably your firm's process actually catches those conflicts.",
+  },
+  {
+    q: "Is this legal advice?",
+    a: "No. This tool audits your firm's conflict-checking process. It does not evaluate any specific conflict and does not tell you whether you may take a particular matter. Rule citations reference the ABA Model Rules of Professional Conduct; your state's rules govern and may differ.",
+  },
+  {
+    q: "Do you store my answers?",
+    a: "The audit runs in your browser and we do not tie results to you. If you choose to share your firm size, state, and practice area at the end, those three fields are stored anonymously so we can build conflict-checking benchmarks for firms like yours. You are never asked for your name, your firm's name, or an email to see your result.",
+  },
+  {
+    q: "How long does it take?",
+    a: "Under three minutes. Eight multiple-choice questions, no signup.",
+  },
+];

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -21,6 +21,7 @@ Primary domain: https://counterbench.ai
 - Guides (answer hubs): https://counterbench.ai/guides
 - Collections: https://counterbench.ai/tools/collections
 - Compare: https://counterbench.ai/tools/compare
+- Conflict Check Blind Spot Audit (free, 8 questions, answers "what is a law firm conflict check" and scores how reliably a firm's process catches conflicts): https://counterbench.ai/tools/conflict-check-audit
 - Prompts library: https://counterbench.ai/prompts
 - Prompt packs: https://counterbench.ai/prompts/packs
 - Playbooks: https://counterbench.ai/playbooks


### PR DESCRIPTION
## What

New free tool at **`/tools/conflict-check-audit`** — an eight-question audit of how a firm *actually* runs conflict checks. Returns a 0–24 score, a risk tier, and a ranked blind-spot list (cheapest fix first, structural last). Implements `tasks/PRD-conflict-check-audit.md` v1.

Each question maps to the ABA Model Rule it tests: **1.7, 1.9, 1.10, 1.13, 1.18, 1.7(b)**.

## Why

Search evidence (Ahrefs, US): the conflict-check cluster is ~1,100/mo at **KD 0–5**, and a **DR 8** site currently holds page one — counterbench.ai is DR 10, so it's winnable. High commercial intent (`law firm conflict check` CPC ~$6, `conflict check software` ~$7). The tool also qualifies Paralegal Teams buyers: a firm can't answer "who can run a complete check today?" with "one person" and still believe its process is institutional.

## Files (7)

| File | What |
|---|---|
| `lib/conflict-check-audit.ts` | Pure data + scoring, fully unit-tested |
| `components/ConflictCheckAudit.tsx` | Client form, tier-aware vendor-neutral CTA, optional 3-field anonymous benchmark (no email gate), print-to-PDF |
| `app/tools/conflict-check-audit/page.tsx` | Server component: first-40-word snippet answer, `SoftwareApplication` + `FAQPage` JSON-LD, full crawlable reference block |
| `__tests__/conflict-check-audit.test.ts` | 22 tests (tier boundaries, triggers, ordering, integrity) |
| `app/sitemap.ts`, `public/llms.txt`, `app/globals.css` | Route entry, AEO entry, scoped styles |

## Notes for review

- **Vendor-neutral, not legal advice, process-only.** Never states whether a firm may take a matter. Never uses the (false) both-layers moat line.
- **Rule citations** carry a `LAST_VERIFIED` date and a state-variance caveat. Worth a lawyer's eyeball before launch — they're the standard Model Rules but state rules govern.
- **No `lib/analytics.ts` dependency.** dataLayer helpers are inlined; event shapes (`tool_view`, `tool_click_cta`) match the analytics module so GTM sees identical events if/when it's extended. Fold in later if desired.
- **Benchmark row is dataLayer-only in v1** — no server sink yet. Wire one before this sees real traffic if the benchmark dataset matters.
- **Deferred per PRD:** email gate, two-respondent mode, state pages, benchmark report.

## Verify gate (off `origin/main`)

typecheck 0 · lint 0 · vitest 22/22 · build passes, route prerenders **static** with no `analytics.ts` present · SSR baseline curl'd (all questions/rules/tiers/JSON-LD in static HTML) · full browser flow driven (scoring, findings, benchmark capture, analytics all confirmed).