### PR TITLE
feat(conflict-audit): persist benchmark rows server-side

### DIFF
--- a/__tests__/conflict-audit-benchmark.test.ts
+++ b/__tests__/conflict-audit-benchmark.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit tests: /api/conflict-audit-benchmark input normalization.
+ *
+ * Covers the validation layer that keeps hostile or malformed POSTs from
+ * poisoning the benchmark dataset. The DB insert itself is not exercised here
+ * (integration concern); normalizeBenchmark is pure and the unit under test.
+ *
+ * Run: npx vitest run __tests__/conflict-audit-benchmark.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { normalizeBenchmark } from "@/lib/conflict-benchmark";
+
+describe("normalizeBenchmark — score", () => {
+  it("accepts an in-range integer", () => {
+    const r = normalizeBenchmark({ score: 16, tier: "person_dependent" });
+    expect(r).toMatchObject({ score: 16 });
+  });
+  it("coerces numeric strings", () => {
+    const r = normalizeBenchmark({ score: "0", tier: "undocumented" });
+    expect(r).toMatchObject({ score: 0 });
+  });
+  it("rejects out-of-range", () => {
+    expect(normalizeBenchmark({ score: 25, tier: "documented" })).toHaveProperty("error");
+    expect(normalizeBenchmark({ score: -1, tier: "documented" })).toHaveProperty("error");
+  });
+  it("rejects non-integers and junk", () => {
+    expect(normalizeBenchmark({ score: 3.5, tier: "reactive" })).toHaveProperty("error");
+    expect(normalizeBenchmark({ score: "abc", tier: "reactive" })).toHaveProperty("error");
+    expect(normalizeBenchmark({ score: null, tier: "reactive" })).toHaveProperty("error");
+  });
+});
+
+describe("normalizeBenchmark — tier", () => {
+  it("accepts the four known tiers", () => {
+    for (const tier of ["documented", "person_dependent", "reactive", "undocumented"]) {
+      expect(normalizeBenchmark({ score: 10, tier })).not.toHaveProperty("error");
+    }
+  });
+  it("rejects unknown tiers", () => {
+    expect(normalizeBenchmark({ score: 10, tier: "Person-dependent" })).toHaveProperty("error");
+    expect(normalizeBenchmark({ score: 10, tier: "" })).toHaveProperty("error");
+    expect(normalizeBenchmark({ score: 10, tier: 5 })).toHaveProperty("error");
+  });
+});
+
+describe("normalizeBenchmark — firmographics drop to null, never reject", () => {
+  it("keeps valid firm sizes, nulls the rest", () => {
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", firm_size: "6-10" })).toMatchObject({ firmSize: "6-10" });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", firm_size: "unspecified" })).toMatchObject({ firmSize: null });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", firm_size: "HUGE" })).toMatchObject({ firmSize: null });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive" })).toMatchObject({ firmSize: null });
+  });
+
+  it("normalizes state to a 2-letter uppercase code or null", () => {
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", state: "ca" })).toMatchObject({ state: "CA" });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", state: " ny " })).toMatchObject({ state: "NY" });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", state: "California" })).toMatchObject({ state: null });
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", state: "" })).toMatchObject({ state: null });
+  });
+
+  it("clamps practice area to 80 chars, nulls empty", () => {
+    const long = "x".repeat(200);
+    const r = normalizeBenchmark({ score: 1, tier: "reactive", practice_area: long });
+    expect((r as { practiceArea: string }).practiceArea).toHaveLength(80);
+    expect(normalizeBenchmark({ score: 1, tier: "reactive", practice_area: "  " })).toMatchObject({ practiceArea: null });
+  });
+
+  it("never stores anything resembling PII from unexpected fields", () => {
+    // Extra fields (name, email) are simply ignored — not in the output shape.
+    const r = normalizeBenchmark({
+      score: 8,
+      tier: "reactive",
+      // @ts-expect-error — hostile extra fields must be dropped, not stored
+      email: "leak@example.com",
+      name: "Jane Doe",
+    });
+    expect(Object.keys(r as object).sort()).toEqual(["firmSize", "practiceArea", "score", "state", "tier"]);
+  });
+});

--- a/app/api/conflict-audit-benchmark/route.ts
+++ b/app/api/conflict-audit-benchmark/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { conflictAuditBenchmarksTable } from "@/lib/db/schema";
+import { normalizeBenchmark, type BenchmarkInput } from "@/lib/conflict-benchmark";
+
+// Force dynamic + node runtime — this hits the DB at request time and must not
+// be evaluated during the build's page-data collection.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// ---------------------------------------------------------------------------
+// In-memory rate limit: 10 POSTs per IP per hour. The IP is used ONLY for
+// throttling and is never stored — benchmark rows carry no PII (see schema).
+// ---------------------------------------------------------------------------
+const RATE_LIMIT_MAX = 10;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const ipHits = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const hits = (ipHits.get(ip) ?? []).filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+  if (hits.length >= RATE_LIMIT_MAX) {
+    ipHits.set(ip, hits);
+    return true;
+  }
+  hits.push(now);
+  ipHits.set(ip, hits);
+  return false;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, hits] of ipHits) {
+    const valid = hits.filter((t) => now - t < RATE_LIMIT_WINDOW_MS);
+    if (valid.length === 0) ipHits.delete(ip);
+    else ipHits.set(ip, valid);
+  }
+}, 10 * 60 * 1000).unref();
+
+function getClientIp(req: Request): string {
+  const fwd = req.headers.get("x-forwarded-for");
+  if (fwd) {
+    const first = fwd.split(",")[0];
+    return first ? first.trim() : "unknown";
+  }
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+export async function POST(req: Request) {
+  if (isRateLimited(getClientIp(req))) {
+    return NextResponse.json({ ok: false }, { status: 429 });
+  }
+
+  const json = (await req.json().catch(() => null)) as BenchmarkInput | null;
+  if (!json) {
+    return NextResponse.json({ ok: false, message: "Invalid body" }, { status: 400 });
+  }
+
+  const row = normalizeBenchmark(json);
+  if ("error" in row) {
+    return NextResponse.json({ ok: false, message: row.error }, { status: 400 });
+  }
+
+  try {
+    await db.insert(conflictAuditBenchmarksTable).values(row);
+  } catch (err) {
+    // Graceful degradation: if the table hasn't been pushed to the DB yet, or
+    // the DB is briefly unavailable, do not break the visitor's experience —
+    // the benchmark is optional and the client only needs a 200 to say thanks.
+    // Logged so a missing-table state is visible in Vercel logs.
+    console.error({ event: "conflict_benchmark_insert_failed", err: String(err) });
+    return NextResponse.json({ ok: true, persisted: false });
+  }
+
+  return NextResponse.json({ ok: true, persisted: true });
+}

--- a/components/ConflictCheckAudit.tsx
+++ b/components/ConflictCheckAudit.tsx
@@ -77,8 +77,7 @@ export function ConflictCheckAudit() {
   }
 
   function saveBenchmark() {
-    // v1: no backend. Record the anonymous row into the dataLayer only; a real
-    // sink can consume the event later without changing this component.
+    // Analytics (GTM) — unchanged, "unspecified" for empty firmographics.
     pushEvent({
       event: "conflict_audit_benchmark",
       tool_slug: TOOL_SLUG,
@@ -88,6 +87,25 @@ export function ConflictCheckAudit() {
       state: benchmark.state || "unspecified",
       practice_area: benchmark.practice || "unspecified",
     });
+
+    // Persist the anonymous row server-side. Fire-and-forget: the benchmark is
+    // optional, so a failed/slow POST must never block the "thanks" state or
+    // surface an error. Empty firmographics are omitted (server stores null).
+    void fetch("/api/conflict-audit-benchmark", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({
+        score: result.score,
+        tier: result.tier.key,
+        firm_size: benchmark.size || undefined,
+        state: benchmark.state || undefined,
+        practice_area: benchmark.practice || undefined,
+      }),
+    }).catch(() => {
+      /* optional telemetry; ignore network errors */
+    });
+
     setBenchmarkSent(true);
   }
 

--- a/lib/conflict-benchmark.ts
+++ b/lib/conflict-benchmark.ts
@@ -1,0 +1,62 @@
+/**
+ * Validation for anonymous Conflict Check Audit benchmark submissions.
+ *
+ * Kept out of the route file so it stays pure and unit-testable (Next.js route
+ * modules may only export handlers + config). Mirrors the client contract in
+ * lib/conflict-check-audit.ts. Anything outside the allowlists drops to null
+ * (firmographics) or is rejected (score/tier), so a malformed or hostile POST
+ * cannot poison the benchmark dataset.
+ */
+
+const TIERS = new Set(["documented", "person_dependent", "reactive", "undocumented"]);
+const FIRM_SIZES = new Set(["solo", "2-5", "6-10", "11-25", "25+"]);
+const PRACTICE_MAX = 80;
+
+export interface BenchmarkInput {
+  score: unknown;
+  tier: unknown;
+  firm_size?: unknown;
+  state?: unknown;
+  practice_area?: unknown;
+}
+
+export interface NormalizedRow {
+  score: number;
+  tier: string;
+  firmSize: string | null;
+  state: string | null;
+  practiceArea: string | null;
+}
+
+/** Returns a clean row, or an error string naming the first hard failure. */
+export function normalizeBenchmark(body: BenchmarkInput): NormalizedRow | { error: string } {
+  // Accept a number, or a non-empty numeric string. Reject null/bool/object/
+  // empty-string — Number() coerces those to 0/1 and would silently store junk.
+  let score: number;
+  if (typeof body.score === "number") {
+    score = body.score;
+  } else if (typeof body.score === "string" && body.score.trim() !== "") {
+    score = Number(body.score);
+  } else {
+    return { error: "score must be a number 0–24" };
+  }
+  if (!Number.isInteger(score) || score < 0 || score > 24) {
+    return { error: "score must be an integer 0–24" };
+  }
+
+  const tier = typeof body.tier === "string" ? body.tier : "";
+  if (!TIERS.has(tier)) {
+    return { error: "unknown tier" };
+  }
+
+  const rawSize = typeof body.firm_size === "string" ? body.firm_size : "";
+  const firmSize = FIRM_SIZES.has(rawSize) ? rawSize : null;
+
+  const rawState = typeof body.state === "string" ? body.state.trim().toUpperCase() : "";
+  const state = /^[A-Z]{2}$/.test(rawState) ? rawState : null;
+
+  const rawPractice = typeof body.practice_area === "string" ? body.practice_area.trim() : "";
+  const practiceArea = rawPractice ? rawPractice.slice(0, PRACTICE_MAX) : null;
+
+  return { score, tier, firmSize, state, practiceArea };
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, varchar, text, timestamp, numeric } from "drizzle-orm/pg-core";
+import { pgTable, varchar, text, timestamp, numeric, integer } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 
 export const contactSubmissionsTable = pgTable("contact_submissions", {
@@ -42,5 +42,19 @@ export const receptionistCallsTable = pgTable("receptionist_calls", {
   transcript: text("transcript"),
   structuredData: text("structured_data"),
   duration: numeric("duration"),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+});
+
+// Anonymous benchmark rows from the Conflict Check Blind Spot Audit
+// (/tools/conflict-check-audit). Deliberately carries NO PII: no name, no firm
+// name, no email, no IP. Only the score, tier, and the three firmographics the
+// user opts to share, so we can publish "firms like yours" benchmarks.
+export const conflictAuditBenchmarksTable = pgTable("conflict_audit_benchmarks", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  score: integer("score").notNull(), // 0–24
+  tier: text("tier").notNull(), // documented | person_dependent | reactive | undocumented
+  firmSize: text("firm_size"), // solo | 2-5 | 6-10 | 11-25 | 25+ | null
+  state: varchar("state", { length: 2 }), // US 2-letter, or null
+  practiceArea: text("practice_area"), // free text, clamped server-side, or null
   createdAt: timestamp("created_at").defaultNow().notNull(),
 });


### PR DESCRIPTION
## What

Wires the Conflict Check Audit's benchmark from **dataLayer-only → a real server sink**, so `PRD-conflict-check-audit.md` Metric #6 (n=200 → *State of Conflict Checking* report) can start accumulating. Follows PR #27 (the tool, now live).

## ⚠️ One manual step required to activate (production-DB boundary)

This PR adds the table to the schema but **does not create it in the Neon prod DB** — that write wasn't mine to make. After merge:

```bash
npx drizzle-kit push
```

Until that runs, the route degrades gracefully: valid POSTs return `200 {persisted:false}`, nothing is stored, and the live tool is unaffected. No regression either way.

## Files (5)

| File | What |
|---|---|
| `lib/db/schema.ts` | `conflict_audit_benchmarks` table — **anonymous by design**: no name/firm/email/IP, only score, tier, opt-in firmographics |
| `app/api/conflict-audit-benchmark/route.ts` | POST handler: IP rate-limit (throttle only, IP never stored), drizzle insert, **graceful catch** on missing-table/DB-down |
| `lib/conflict-benchmark.ts` | Pure `normalizeBenchmark()` validation (separate module so route exports stay handler-only) |
| `components/ConflictCheckAudit.tsx` | `saveBenchmark` POSTs the row (fire-and-forget, keepalive; GTM push kept) |
| `__tests__/conflict-audit-benchmark.test.ts` | 10 tests |

## Data hygiene

- **No PII.** Extra fields (name/email) in a POST are ignored, never stored — covered by a test.
- Allowlisted `tier` / `firm_size`; `state` regex-validated to 2 letters; `practice_area` clamped to 80 chars; out-of-range/junk `score` rejected.
- IP is used only for rate-limiting and is never written to the row.

## A bug review caught

First cut used `Number(body.score)` — `Number(null) === 0`, so a null-score POST would have stored a valid-looking **0**, poisoning the dataset. A test flagged it; fixed to reject non-numeric input.

## Verify gate (off `origin/main`)

typecheck 0 · lint 0 · vitest **10/10** (+22 existing audit tests) · build passes (route is a serverless function) · **endpoint driven live against an unreachable DB**: junk → 400, bad tier → 400, non-JSON → 400, valid + DB-down → 200 `persisted:false`.

## Follow-up (not blocking)

- Rule citations on the live tool still want a lawyer's eyeball (carried from PR #27).