### PR TITLE
feat(ops): concurrent-session isolation helpers (portfolio roll)

### DIFF
--- a/scripts/lib/resolve-canonical.mjs
+++ b/scripts/lib/resolve-canonical.mjs
@@ -1,0 +1,55 @@
+// resolve-canonical.mjs — resolve a canonical file by CONTENT, not by a
+// hardcoded path (WS4 of PRD-concurrent-session-isolation).
+//
+// WHY: canonical docs move across concurrent sessions. On 2026-07-22 the
+// voice-identity file moved three times in one day (.claude/rules/ ->
+// .claude/reference/ -> content/voice/), each move leaving a markerless pointer
+// stub. Every script that hardcoded one path broke (content-gate.mjs exited 2
+// on every draft). The durable fix: give the reader an ordered list of
+// candidate paths and a marker string that only the REAL file contains, and let
+// it pick the first candidate that actually carries the marker. A retired path
+// left behind as a stub never wins; a new home is a one-line prepend.
+//
+// Pure, dependency-free, synchronous. Import into any gate/script.
+
+import { readFileSync, existsSync } from 'node:fs';
+import { relative } from 'node:path';
+
+/**
+ * @param {string[]} candidates  Absolute paths, most-current first.
+ * @param {string}   marker      A line/substring only the real file contains.
+ * @param {object}   [opts]
+ * @param {boolean}  [opts.exactLine=false]  Marker must equal a trimmed line
+ *                                            (not just appear as a substring).
+ * @param {string}   [opts.root=process.cwd()] For tidy error paths.
+ * @returns {{ path: string, text: string }}
+ * @throws  If no candidate exists AND contains the marker. The error names every
+ *          path searched, so a failure is diagnosable, not a mystery.
+ */
+export function resolveCanonical(candidates, marker, opts = {}) {
+  const { exactLine = false, root = process.cwd() } = opts;
+  if (!Array.isArray(candidates) || candidates.length === 0) {
+    throw new Error('resolveCanonical: candidates must be a non-empty array');
+  }
+  if (typeof marker !== 'string' || marker === '') {
+    throw new Error('resolveCanonical: marker must be a non-empty string');
+  }
+  const searched = [];
+  for (const cand of candidates) {
+    searched.push(relative(root, cand));
+    if (!existsSync(cand)) continue;
+    const text = readFileSync(cand, 'utf8');
+    const hit = exactLine
+      ? text.split('\n').some((l) => l.trim() === marker)
+      : text.includes(marker);
+    if (hit) return { path: cand, text };
+    // exists but no marker: a pointer stub. Keep looking.
+  }
+  throw new Error(
+    `resolveCanonical: no candidate contained the marker ${JSON.stringify(marker)}. ` +
+      `Searched, in order:\n  ${searched.join('\n  ')}\n` +
+      `Add the file's new home to the FRONT of the candidate list.`,
+  );
+}
+
+export default resolveCanonical;

--- a/scripts/predeploy-check.sh
+++ b/scripts/predeploy-check.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# predeploy-check.sh — assert the tree is safe to ship to production (WS5).
+#
+# `vercel --prod` ships the LOCAL working tree. In a checkout shared by
+# concurrent sessions that tree can hold another session's uncommitted work or
+# be on a branch a sibling switched under you (see project_mettle_concurrent_
+# sessions). Run this BEFORE any prod deploy — manually, in CI, or as a step in
+# a deploy script. The pretool-deploy-guard.py hook enforces the same for Claude
+# Bash calls; this covers the paths a hook can't (CI, non-Claude agents, humans).
+#
+# Exit 0 = safe. Exit 1 = blocked (dirty tree or branch drift). Bypass: set
+# DEPLOY_GUARD_BYPASS=1.
+#
+# Usage:  scripts/predeploy-check.sh && vercel --prod
+
+set -euo pipefail
+
+[ "${DEPLOY_GUARD_BYPASS:-}" = "1" ] && exit 0
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "predeploy-check: not in a git repo, skipping." >&2
+  exit 0
+fi
+
+dirty="$(git status --porcelain)"
+if [ -n "$dirty" ]; then
+  n="$(printf '%s\n' "$dirty" | grep -c . || true)"
+  echo "BLOCKED: working tree has $n uncommitted change(s). A prod deploy ships" >&2
+  echo "the local tree, which in a shared checkout may be another session's work." >&2
+  echo "Commit or stash-by-path, then deploy from a clean tree." >&2
+  echo "Override: DEPLOY_GUARD_BYPASS=1" >&2
+  exit 1
+fi
+
+gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+if [ -n "$gitdir" ] && [ -f "$gitdir/session-branch" ]; then
+  expected="$(tr -d '[:space:]' < "$gitdir/session-branch")"
+  actual="$(git branch --show-current)"
+  if [ -n "$expected" ] && [ "$expected" != "$actual" ]; then
+    echo "BLOCKED: session expected branch '$expected' but HEAD is '$actual'." >&2
+    echo "A concurrent session likely switched the checkout. Confirm what you're shipping." >&2
+    echo "Override: DEPLOY_GUARD_BYPASS=1" >&2
+    exit 1
+  fi
+fi
+
+echo "predeploy-check: clean tree on $(git branch --show-current). Safe to deploy."

--- a/scripts/session-worktree.sh
+++ b/scripts/session-worktree.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# session-worktree.sh — one isolated git worktree per agent session.
+#
+# WHY: multiple Claude/Codex sessions sharing one checkout clobber each other's
+# branch, working tree, and stash (see _ops/PRD-concurrent-session-isolation.md).
+# The fix is that every session that will WRITE works in its own worktree, and
+# the primary checkout stays a read/inspection surface. This script is the WS1
+# primitive that makes that cheap and standard.
+#
+# CONVENTION (the whole point — one location, not three):
+#   <repo>/.worktrees/<slug>     always. Never /private/tmp, never .claude/worktrees.
+#   `.worktrees/` is gitignored, so a sibling session's `git add -A` can't absorb it.
+#
+# USAGE:
+#   scripts/session-worktree.sh new <slug> [base-branch]   # create + print cd path
+#   scripts/session-worktree.sh list                        # show session worktrees
+#   scripts/session-worktree.sh prune                        # remove merged/orphaned
+#
+# `new` creates worktree <repo>/.worktrees/<slug> on a fresh branch
+# feat/<slug> off <base-branch> (default: origin/main, fetched first), records the
+# session's expected branch for the git-safety hook, and seeds .claude so skills
+# and hooks resolve inside the worktree. It prints the path to cd into; it does
+# not cd for you (a script can't change the caller's shell).
+
+set -euo pipefail
+
+# The MAIN checkout root, resolved even when called from inside a worktree, so
+# every session worktree lands in ONE place: <main>/.worktrees/. Using
+# --show-toplevel would return the current worktree and nest them.
+main_root() {
+  local cdir
+  cdir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  # Standard layout: common dir is <main>/.git, so the main worktree is its parent.
+  dirname "$cdir"
+}
+
+cmd_new() {
+  local slug="${1:?usage: session-worktree.sh new <slug> [base-branch]}"
+  local base="${2:-origin/main}"
+  local root; root="$(main_root)" || { echo "not in a git repo" >&2; exit 1; }
+  local wt="$root/.worktrees/$slug"
+  local branch="feat/$slug"
+
+  if [ -e "$wt" ]; then
+    echo "worktree already exists: $wt" >&2
+    echo "$wt"
+    return 0
+  fi
+
+  # Fetch so origin/* bases are current; ignore failure (offline is fine).
+  case "$base" in origin/*) git -C "$root" fetch -q origin "${base#origin/}" || true ;; esac
+
+  git -C "$root" worktree add "$wt" -b "$branch" "$base" >&2
+
+  # Record the session's expected branch for pretool-git-safety.py branch-drift
+  # check. Path-format absolute so it resolves from anywhere.
+  local common; common="$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  # In a worktree, per-worktree git dir differs from the common dir; write the
+  # marker in the worktree's OWN git dir so each session has its own expectation.
+  local wtgit; wtgit="$(git -C "$wt" rev-parse --absolute-git-dir 2>/dev/null || true)"
+  [ -n "$wtgit" ] && printf '%s\n' "$branch" > "$wtgit/session-branch"
+
+  # Seed .claude so gitignored skills/hooks/reference resolve inside the worktree.
+  # Symlink (cheap, always current) rather than copy (drifts).
+  if [ -d "$root/.claude" ] && [ ! -e "$wt/.claude" ]; then
+    ln -s "$root/.claude" "$wt/.claude"
+  fi
+
+  echo "$wt"   # stdout = the path to cd into
+}
+
+cmd_list() {
+  local root; root="$(main_root)"
+  git -C "$root" worktree list | grep -F "/.worktrees/" || echo "(no session worktrees)"
+}
+
+cmd_prune() {
+  local root; root="$(main_root)"
+  # Remove git's stale administrative entries first.
+  git -C "$root" worktree prune -v >&2 || true
+  # Then remove session worktrees whose branch is fully merged into origin/main.
+  git -C "$root" fetch -q origin main || true
+  git -C "$root" worktree list --porcelain | awk '/^worktree /{p=$2} /^branch /{b=$2; if (p ~ /\/\.worktrees\//) print p" "b}' \
+  | while read -r path ref; do
+      local br="${ref#refs/heads/}"
+      if git -C "$root" merge-base --is-ancestor "$ref" origin/main 2>/dev/null; then
+        echo "pruning merged worktree: $path ($br)" >&2
+        git -C "$root" worktree remove "$path" --force 2>/dev/null \
+          && git -C "$root" branch -D "$br" 2>/dev/null || true
+      fi
+    done
+}
+
+case "${1:-}" in
+  new)   shift; cmd_new "$@" ;;
+  list)  cmd_list ;;
+  prune) cmd_prune ;;
+  *) echo "usage: session-worktree.sh {new <slug> [base] | list | prune}" >&2; exit 2 ;;
+esac

--- a/scripts/session-worktrees.md
+++ b/scripts/session-worktrees.md
@@ -1,0 +1,57 @@
+# Session worktrees — concurrent-session isolation (WS1)
+
+Pilot of `_ops/PRD-concurrent-session-isolation.md`. This is how multiple Claude/Codex
+sessions work in this repo at the same time without clobbering each other.
+
+## The rule
+
+**The primary checkout is read-only to agents.** Any session that will WRITE works in its
+own worktree at `<repo>/.worktrees/<slug>`. One location, always. Not `/private/tmp`, not
+`.claude/worktrees/` — those three competing conventions are what produced the sprawl the
+PRD documents.
+
+Why this exists: git working state (branch, working tree, index, stash) is global to a
+checkout. Two sessions sharing one checkout switch each other's branch, capture each other's
+stash, and leak each other's dirty tree to `vercel --prod`. A worktree gives each session its
+own branch + tree + index, so none of that can happen.
+
+## Usage
+
+```bash
+# start an isolated session (creates <repo>/.worktrees/<slug> on feat/<slug> off origin/main)
+scripts/session-worktree.sh new my-task
+cd "$(scripts/session-worktree.sh new my-task)"   # or cd the printed path
+
+scripts/session-worktree.sh list     # show session worktrees
+scripts/session-worktree.sh prune    # remove worktrees whose branch merged into origin/main
+```
+
+`new` also:
+- writes the session's expected branch to the worktree's git dir (`session-branch`), which
+  `~/.claude/hooks/pretool-git-safety.py` reads to block a commit/push after another session
+  switches your branch out from under you;
+- symlinks `.claude` into the worktree so gitignored skills/hooks/reference resolve.
+
+## How the pieces fit
+
+| Piece | Role |
+|---|---|
+| `scripts/session-worktree.sh` | Creates the isolated worktree at the standard path (this WS1). |
+| `~/.claude/hooks/pretool-git-safety.py` | Blocks blind `git stash` and branch-drift commits (WS2). Reads the `session-branch` marker this script writes. |
+| `scripts/lib/resolve-canonical.mjs` | Content-keyed path resolution so a file moved across sessions doesn't break its readers (WS4). |
+| `~/.claude/hooks/sessionstart-session-registry.py` | Records each session in `.orchestra/session-registry.json` + writes the `session-branch` marker; `--who` shows other live sessions; TTL-reaps dead ones (WS3). |
+| `~/.claude/hooks/pretool-deploy-guard.py` + `scripts/predeploy-check.sh` | Block `vercel --prod` from a dirty tree or a drifted branch (WS5). The hook covers Claude; the script covers CI / humans / other agents. |
+
+## Before you claim an area
+
+Run this to see who else is live in the repo, so two sessions don't fix the same file:
+
+```bash
+python3 ~/.claude/hooks/sessionstart-session-registry.py --who
+```
+
+## Remaining wiring (owner: Phil)
+
+- `.gitignore`: add `.worktrees/` (agents are hook-blocked from editing .gitignore). Belt-and-suspenders so a sibling session's `git add -A` can never absorb a worktree.
+- `settings.json`: wire `pretool-git-safety.py` (see `_ops/PRD-concurrent-session-isolation-BUILD-LOG.md`).
+- A one-line pointer to this doc from `CLAUDE.md §3 Git` (CLAUDE.md is edited under concurrent churn; left to Phil to avoid a conflicting write).


### PR DESCRIPTION
Ports the repo-local isolation helpers from Petrichor PR #155. Enforcement hooks are global (~/.claude/hooks) and already cover this repo; this adds the repo side: session-worktree.sh, predeploy-check.sh, lib/resolve-canonical.mjs, convention doc. Scripts only, not in the build. Committed from an isolated worktree.