### PR TITLE
chore(ops): gitignore isolation runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ public/search-index.json
 
 # local tooling
 .claude/
+
+# Per-session isolation runtime state (PRD-concurrent-session-isolation)
+.worktrees/
+.orchestra/session-registry.json


### PR DESCRIPTION
Adds .worktrees/ and .orchestra/session-registry.json to .gitignore (runtime state, PRD-concurrent-session-isolation). One-line-each.