### PR TITLE
feat(tools): Paralegal Capacity Calculator

### DIFF
--- a/__tests__/paralegal-capacity.test.ts
+++ b/__tests__/paralegal-capacity.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Unit tests: Paralegal Capacity Calculator scoring.
+ *
+ * Locks the pure logic in lib/paralegal-capacity.ts:
+ *   - practice type target bands
+ *   - core ratio math (division-by-zero guards on paralegals/attorneys)
+ *   - status thresholds (green/amber/red boundaries, attorney-ratio override)
+ *   - gated report math (casesUnderServed, staffingGap)
+ *
+ * Run: npx vitest run __tests__/paralegal-capacity.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateCapacity,
+  practiceTypeTarget,
+  practiceTypeLabel,
+  statusLabel,
+  verdictSentence,
+  recommendation,
+  PRACTICE_TYPE_TARGETS,
+  PRACTICE_TYPES,
+  DEFAULT_PRACTICE_TYPE,
+  type CapacityInputs
+} from "@/lib/paralegal-capacity";
+
+describe("practice type targets", () => {
+  it("matches the fixed rule-of-thumb bands", () => {
+    expect(PRACTICE_TYPE_TARGETS).toEqual({
+      auto: 70,
+      premises: 60,
+      medmal: 35,
+      masstort: 40,
+      mixed: 50
+    });
+  });
+
+  it("defaults to mixed", () => {
+    expect(DEFAULT_PRACTICE_TYPE).toBe("mixed");
+  });
+
+  it("every listed practice type has a target and a label", () => {
+    for (const pt of PRACTICE_TYPES) {
+      expect(practiceTypeTarget(pt)).toBeGreaterThan(0);
+      expect(practiceTypeLabel(pt).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("calculateCapacity - core ratios", () => {
+  it("computes cases per paralegal and attorney ratio for a normal case", () => {
+    const inputs: CapacityInputs = { attorneys: 3, paralegals: 5, activeCases: 460, newIntakesPerMonth: 50, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    expect(r.target).toBe(50);
+    expect(r.casesPerParalegal).toBeCloseTo(92, 5);
+    expect(r.attorneyRatio).toBeCloseTo(5 / 3, 5);
+    expect(r.overloadPct).toBeCloseTo(84, 5);
+    expect(r.intakeLoadPerPara).toBeCloseTo(10, 5);
+  });
+
+  it("guards division by zero when paralegals is 0 (uses max(paralegals,1) for ratios)", () => {
+    const inputs: CapacityInputs = { attorneys: 2, paralegals: 0, activeCases: 100, newIntakesPerMonth: 10, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    expect(r.casesPerParalegal).toBeCloseTo(100, 5); // 100 / max(0,1)
+    expect(r.intakeLoadPerPara).toBeCloseTo(10, 5); // 10 / max(0,1)
+    expect(r.attorneyRatio).toBe(0); // raw paralegals (0) / max(attorneys,1)
+  });
+
+  it("guards division by zero when attorneys is 0 (uses max(attorneys,1) for attorneyRatio)", () => {
+    const inputs: CapacityInputs = { attorneys: 0, paralegals: 2, activeCases: 50, newIntakesPerMonth: 5, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    expect(r.attorneyRatio).toBeCloseTo(2, 5); // 2 / max(0,1)
+  });
+
+  it("defaults to the mixed target when practiceType is omitted", () => {
+    const inputs: CapacityInputs = { attorneys: 2, paralegals: 2, activeCases: 100, newIntakesPerMonth: 10 };
+    const r = calculateCapacity(inputs);
+    expect(r.target).toBe(50);
+  });
+});
+
+describe("calculateCapacity - status thresholds", () => {
+  const base = { attorneys: 4, newIntakesPerMonth: 10, practiceType: "mixed" as const };
+
+  it("green when overloadPct <= 0", () => {
+    // casesPerParalegal = 50 -> overloadPct = 0
+    expect(calculateCapacity({ ...base, paralegals: 2, activeCases: 100 }).status).toBe("green");
+    // casesPerParalegal = 45 -> overloadPct = -10
+    expect(calculateCapacity({ ...base, paralegals: 2, activeCases: 90 }).status).toBe("green");
+  });
+
+  it("amber when 0 < overloadPct <= 40", () => {
+    // casesPerParalegal = 70 -> overloadPct = 40 (boundary, inclusive)
+    expect(calculateCapacity({ ...base, paralegals: 2, activeCases: 140 }).status).toBe("amber");
+    // casesPerParalegal = 60 -> overloadPct = 20
+    expect(calculateCapacity({ ...base, paralegals: 2, activeCases: 120 }).status).toBe("amber");
+  });
+
+  it("red when overloadPct > 40", () => {
+    // casesPerParalegal = 71 -> overloadPct = 42
+    expect(calculateCapacity({ ...base, paralegals: 2, activeCases: 142 }).status).toBe("red");
+  });
+
+  it("red when attorneyRatio < 0.5, even if overloadPct is low", () => {
+    // paralegals=1, attorneys=3 -> ratio = 0.333; casesPerParalegal = 10 -> overloadPct = -80 (would be green)
+    const r = calculateCapacity({ attorneys: 3, paralegals: 1, activeCases: 10, newIntakesPerMonth: 5, practiceType: "mixed" });
+    expect(r.attorneyRatio).toBeLessThan(0.5);
+    expect(r.overloadPct).toBeLessThan(0);
+    expect(r.status).toBe("red");
+  });
+});
+
+describe("calculateCapacity - gated report math", () => {
+  it("computes casesUnderServed and staffingGap for an over-capacity firm", () => {
+    const inputs: CapacityInputs = { attorneys: 3, paralegals: 5, activeCases: 460, newIntakesPerMonth: 50, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    // casesUnderServed = max(0, 460 - 5*50) = 210
+    expect(r.casesUnderServed).toBe(210);
+    // staffingGap = max(0, ceil(460/50) - 5) = max(0, 10 - 5) = 5
+    expect(r.staffingGap).toBe(5);
+  });
+
+  it("floors both at 0 for an under-capacity firm", () => {
+    const inputs: CapacityInputs = { attorneys: 3, paralegals: 5, activeCases: 100, newIntakesPerMonth: 10, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    expect(r.casesUnderServed).toBe(0);
+    expect(r.staffingGap).toBe(0);
+  });
+
+  it("handles zero paralegals without throwing and reports the full gap", () => {
+    const inputs: CapacityInputs = { attorneys: 2, paralegals: 0, activeCases: 100, newIntakesPerMonth: 10, practiceType: "mixed" };
+    const r = calculateCapacity(inputs);
+
+    // casesUnderServed = max(0, 100 - 0*50) = 100
+    expect(r.casesUnderServed).toBe(100);
+    // staffingGap = max(0, ceil(100/50) - 0) = 2
+    expect(r.staffingGap).toBe(2);
+  });
+});
+
+describe("copy helpers", () => {
+  it("statusLabel covers all three statuses", () => {
+    expect(statusLabel("green")).toBe("Under capacity");
+    expect(statusLabel("amber")).toBe("Approaching capacity");
+    expect(statusLabel("red")).toBe("Over capacity");
+  });
+
+  it("verdictSentence names the over-capacity direction and rounded numbers", () => {
+    const r = calculateCapacity({ attorneys: 3, paralegals: 5, activeCases: 460, newIntakesPerMonth: 50, practiceType: "mixed" });
+    const sentence = verdictSentence(r);
+    expect(sentence).toContain("92");
+    expect(sentence).toContain("84%");
+    expect(sentence).toContain("over");
+  });
+
+  it("verdictSentence names the under-capacity direction", () => {
+    const r = calculateCapacity({ attorneys: 3, paralegals: 5, activeCases: 200, newIntakesPerMonth: 20, practiceType: "mixed" });
+    const sentence = verdictSentence(r);
+    expect(sentence).toContain("under");
+  });
+
+  it("recommendation does not restate the Paralegal Teams price", () => {
+    const r = calculateCapacity({ attorneys: 3, paralegals: 5, activeCases: 460, newIntakesPerMonth: 50, practiceType: "mixed" });
+    const text = recommendation(r, "mixed");
+    expect(text).not.toMatch(/\$3,?750|\$6,?500/);
+  });
+
+  it("recommendation uses singular 'paralegal' when staffingGap is 1", () => {
+    // activeCases just over one paralegal's worth of gap
+    const r = calculateCapacity({ attorneys: 5, paralegals: 4, activeCases: 250, newIntakesPerMonth: 20, practiceType: "mixed" });
+    expect(r.staffingGap).toBe(1);
+    expect(recommendation(r, "mixed")).toContain("1 more paralegal ");
+  });
+
+  it("no copy helper output contains an em dash", () => {
+    const r = calculateCapacity({ attorneys: 3, paralegals: 5, activeCases: 460, newIntakesPerMonth: 50, practiceType: "mixed" });
+    for (const text of [verdictSentence(r), recommendation(r, "mixed"), statusLabel(r.status)]) {
+      expect(text).not.toContain("—");
+    }
+  });
+});

--- a/app/api/newsletter/subscribe/route.ts
+++ b/app/api/newsletter/subscribe/route.ts
@@ -58,26 +58,32 @@ function isValidEmail(email: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
 }
 
-async function readBody(req: Request): Promise<{ email: string; source: string; hp: string }> {
+async function readBody(req: Request): Promise<{ email: string; source: string; hp: string; meta: Record<string, unknown> | null }> {
   const ct = req.headers.get("content-type") || "";
   if (ct.includes("application/json")) {
-    const j = (await req.json().catch(() => ({}))) as { email?: unknown; source?: unknown; hp?: unknown };
+    const j = (await req.json().catch(() => ({}))) as { email?: unknown; source?: unknown; hp?: unknown; meta?: unknown };
     return {
       email: typeof j.email === "string" ? j.email : "",
       source: typeof j.source === "string" ? j.source : "",
-      hp: typeof j.hp === "string" ? j.hp : ""
+      hp: typeof j.hp === "string" ? j.hp : "",
+      // Optional structured context (e.g. a calculator tool's numeric inputs
+      // and computed result) forwarded to the lead notifier alongside the
+      // email. Never required; existing JSON callers that omit it are
+      // unaffected.
+      meta: j.meta && typeof j.meta === "object" && !Array.isArray(j.meta) ? (j.meta as Record<string, unknown>) : null
     };
   }
 
   const fd = await req.formData().catch(() => null);
-  if (!fd) return { email: "", source: "", hp: "" };
+  if (!fd) return { email: "", source: "", hp: "", meta: null };
   const email = fd.get("email");
   const source = fd.get("source");
   const hp = fd.get("company"); // honeypot
   return {
     email: typeof email === "string" ? email : "",
     source: typeof source === "string" ? source : "",
-    hp: typeof hp === "string" ? hp : ""
+    hp: typeof hp === "string" ? hp : "",
+    meta: null
   };
 }
 
@@ -141,7 +147,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { email, source, hp } = await readBody(req);
+  const { email, source, hp, meta } = await readBody(req);
 
   // Honeypot: pretend success for bots.
   if (hp && hp.trim()) {
@@ -214,7 +220,12 @@ export async function POST(req: Request) {
   // Lead forward to n8n (Slack notifier). Awaited: the response below ends the
   // invocation, which on serverless freezes the runtime and drops any in-flight
   // un-awaited fetch. Bounded by a timeout and never throws.
-  await forwardToN8n({ business: "CounterbenchAI", cta: "Newsletter", email: email.trim() });
+  await forwardToN8n({
+    business: "CounterbenchAI",
+    cta: source ? `Newsletter - ${source}` : "Newsletter",
+    email: email.trim(),
+    ...(meta ? { meta } : {})
+  });
 
   return NextResponse.json({ ok: true });
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,6 +18,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/tools/source-finder"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/contract-qa-planner"), lastModified: now, changeFrequency: "weekly", priority: 0.74 },
     { url: absoluteUrl("/tools/conflict-check-audit"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
+    { url: absoluteUrl("/tools/paralegal-capacity-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/guides"), lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: absoluteUrl("/about"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/contact"), lastModified: now, changeFrequency: "monthly", priority: 0.7 },

--- a/app/tools/paralegal-capacity-calculator/page.tsx
+++ b/app/tools/paralegal-capacity-calculator/page.tsx
@@ -1,0 +1,26 @@
+import { ParalegalCapacityCalculator } from "@/components/ParalegalCapacityCalculator";
+
+export const metadata = {
+  title: "Paralegal Capacity Calculator",
+  description:
+    "Enter attorney count, paralegal count, active cases, and monthly intake to see whether your PI firm's paralegal function is over capacity, and by how much."
+};
+
+export default function ParalegalCapacityCalculatorPage() {
+  return (
+    <main>
+      <section className="section" style={{ paddingTop: 108, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label">Free tool</div>
+          <h1 className="max-w-900">Is your paralegal team over capacity?</h1>
+          <p className="max-w-800 mt-4" style={{ fontSize: "1.125rem" }}>
+            Enter a few numbers from your firm and see where paralegal capacity stands against an industry rule of
+            thumb, then unlock the full gap report.
+          </p>
+
+          <ParalegalCapacityCalculator />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/ParalegalCapacityCalculator.tsx
+++ b/components/ParalegalCapacityCalculator.tsx
@@ -1,0 +1,408 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  calculateCapacity,
+  practiceTypeLabel,
+  practiceTypeTarget,
+  recommendation,
+  statusLabel,
+  verdictSentence,
+  DEFAULT_PRACTICE_TYPE,
+  PRACTICE_TYPES,
+  type CapacityInputs,
+  type CapacityStatus,
+  type PracticeType
+} from "@/lib/paralegal-capacity";
+
+const TOOL_SLUG = "paralegal-capacity-calculator";
+
+// Local dataLayer helpers. Event shapes mirror the tool_view / tool_click_cta
+// convention used by the other free tools in this repo (see
+// components/ConflictCheckAudit.tsx); kept inline here so this tool has no
+// cross-module dependency to ship.
+function pushEvent(event: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(event);
+}
+function trackToolView(): void {
+  pushEvent({ event: "tool_view", tool_slug: TOOL_SLUG });
+}
+function trackToolCTA(destination: string): void {
+  pushEvent({ event: "tool_click_cta", tool_slug: TOOL_SLUG, destination });
+}
+
+const STATUS_COLOR: Record<CapacityStatus, string> = {
+  green: "var(--green)",
+  amber: "var(--amber)",
+  red: "var(--red)"
+};
+
+function toNonNegativeInt(raw: string): number {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
+function isValidEmail(email: string): boolean {
+  const e = email.trim();
+  if (e.length < 5 || e.length > 254) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
+}
+
+function fieldStyle(): React.CSSProperties {
+  return {
+    width: "100%",
+    padding: "12px 14px",
+    borderRadius: 999,
+    border: "1px solid var(--border)",
+    background: "var(--input-bg)",
+    color: "var(--fg)"
+  };
+}
+
+export function ParalegalCapacityCalculator() {
+  const [attorneysRaw, setAttorneysRaw] = useState("2");
+  const [paralegalsRaw, setParalegalsRaw] = useState("1");
+  const [activeCasesRaw, setActiveCasesRaw] = useState("120");
+  const [newIntakesRaw, setNewIntakesRaw] = useState("15");
+  const [practiceType, setPracticeType] = useState<PracticeType>(DEFAULT_PRACTICE_TYPE);
+
+  const [email, setEmail] = useState("");
+  const [unlocked, setUnlocked] = useState(false);
+  const [gateStatus, setGateStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [gateMessage, setGateMessage] = useState("");
+
+  useEffect(() => {
+    trackToolView();
+  }, []);
+
+  const inputs: CapacityInputs = useMemo(
+    () => ({
+      attorneys: toNonNegativeInt(attorneysRaw),
+      paralegals: toNonNegativeInt(paralegalsRaw),
+      activeCases: toNonNegativeInt(activeCasesRaw),
+      newIntakesPerMonth: toNonNegativeInt(newIntakesRaw),
+      practiceType
+    }),
+    [attorneysRaw, paralegalsRaw, activeCasesRaw, newIntakesRaw, practiceType]
+  );
+
+  const result = useMemo(() => calculateCapacity(inputs), [inputs]);
+  const target = practiceTypeTarget(practiceType);
+  const hasEnoughInput = inputs.paralegals > 0 && inputs.activeCases > 0;
+
+  async function handleUnlock(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!isValidEmail(email)) {
+      setGateStatus("error");
+      setGateMessage("Enter a valid email.");
+      return;
+    }
+
+    setGateStatus("loading");
+    setGateMessage("");
+
+    try {
+      const res = await fetch("/api/newsletter/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          source: TOOL_SLUG,
+          meta: {
+            tool: TOOL_SLUG,
+            attorneys: inputs.attorneys,
+            paralegals: inputs.paralegals,
+            active_cases: inputs.activeCases,
+            new_intakes_per_month: inputs.newIntakesPerMonth,
+            practice_type: inputs.practiceType,
+            cases_per_paralegal: Math.round(result.casesPerParalegal * 10) / 10,
+            overload_pct: Math.round(result.overloadPct),
+            status: result.status,
+            cases_under_served: result.casesUnderServed,
+            staffing_gap: result.staffingGap
+          }
+        })
+      });
+
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; message?: string };
+
+      if (!res.ok || !data.ok) {
+        setGateStatus("error");
+        setGateMessage(data.message || "Could not unlock the report. Try again in a moment.");
+        return;
+      }
+
+      setUnlocked(true);
+      setGateStatus("idle");
+      pushEvent({ event: "capacity_calc_lead", tool_slug: TOOL_SLUG, status: result.status });
+    } catch {
+      setGateStatus("error");
+      setGateMessage("Network error. Please try again.");
+    }
+  }
+
+  return (
+    <div className="mt-5">
+      <div
+        className="card"
+        style={{
+          borderRadius: 18,
+          border: "1px solid color-mix(in srgb, var(--border) 68%, #0ea5e9 32%)",
+          background:
+            "linear-gradient(160deg, color-mix(in srgb, #111827 84%, #0c4a6e 16%) 0%, color-mix(in srgb, #020617 90%, #0f172a 10%) 100%)"
+        }}
+      >
+        <div className="label">Free tool</div>
+        <div className="text-white" style={{ fontSize: "1.9rem", fontWeight: 850, lineHeight: 1.1, letterSpacing: "-0.03em" }}>
+          Paralegal Capacity Calculator
+        </div>
+        <p className="text-muted" style={{ marginTop: 10, maxWidth: 820, fontSize: "1.03rem", lineHeight: 1.55 }}>
+          Enter your firm&apos;s numbers to see whether your paralegal function is over capacity, and by how much.
+        </p>
+
+        <div
+          className="mt-5"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
+            gap: 10,
+            alignItems: "end"
+          }}
+        >
+          <div>
+            <label className="label" htmlFor="pcc-attorneys">
+              Attorneys
+            </label>
+            <input
+              id="pcc-attorneys"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={attorneysRaw}
+              onChange={(e) => setAttorneysRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="pcc-paralegals">
+              Paralegals
+            </label>
+            <input
+              id="pcc-paralegals"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={paralegalsRaw}
+              onChange={(e) => setParalegalsRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="pcc-active-cases">
+              Active cases
+            </label>
+            <input
+              id="pcc-active-cases"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={activeCasesRaw}
+              onChange={(e) => setActiveCasesRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="pcc-intakes">
+              New intakes / month
+            </label>
+            <input
+              id="pcc-intakes"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={newIntakesRaw}
+              onChange={(e) => setNewIntakesRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="pcc-practice-type">
+              Practice mix
+            </label>
+            <select
+              id="pcc-practice-type"
+              value={practiceType}
+              onChange={(e) => setPracticeType(e.target.value as PracticeType)}
+              style={fieldStyle()}
+            >
+              {PRACTICE_TYPES.map((pt) => (
+                <option key={pt} value={pt}>
+                  {practiceTypeLabel(pt)}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="text-muted" style={{ marginTop: 12, fontSize: "0.8125rem", lineHeight: 1.5 }}>
+          Target caseload for {practiceTypeLabel(practiceType).toLowerCase()} work: {target} active cases per paralegal.
+          This is an industry rule of thumb, not a measured benchmark - adjust it to your firm.
+        </div>
+      </div>
+
+      {!hasEnoughInput ? (
+        <div className="card mt-4" style={{ borderRadius: 16 }}>
+          <div className="text-muted">Enter your paralegal count and active case count above to see your capacity read.</div>
+        </div>
+      ) : (
+        <div className="card mt-4" style={{ borderRadius: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span
+                aria-hidden="true"
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: STATUS_COLOR[result.status]
+                }}
+              />
+              <div>
+                <div className="label" style={{ margin: 0 }}>
+                  {statusLabel(result.status)}
+                </div>
+                <div className="text-white" style={{ fontWeight: 800, fontSize: "1.15rem", letterSpacing: "-0.02em" }}>
+                  {result.casesPerParalegal.toFixed(1)} cases / paralegal - {result.attorneyRatio.toFixed(2)} paralegals / attorney
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-muted" style={{ marginTop: 12, lineHeight: 1.55, fontSize: "1.03rem" }}>
+            {verdictSentence(result)}
+          </p>
+
+          {!unlocked ? (
+            <form
+              onSubmit={handleUnlock}
+              style={{
+                marginTop: 16,
+                padding: "14px 16px",
+                borderRadius: 12,
+                background: "color-mix(in srgb, var(--bg2) 90%, #0ea5e9 10%)",
+                border: "1px solid var(--border)"
+              }}
+            >
+              <div className="text-white" style={{ fontWeight: 700, fontSize: "0.95rem", marginBottom: 6 }}>
+                Unlock the full capacity report
+              </div>
+              <div className="text-muted" style={{ fontSize: "0.82rem", marginBottom: 10, lineHeight: 1.45 }}>
+                See how many cases are past capacity and how many paralegals would close the gap.
+              </div>
+              <div className="flex flex--gap-2 flex--resp-col" style={{ maxWidth: 460 }}>
+                <label className="sr-only" htmlFor="pcc-email">
+                  Email
+                </label>
+                <input
+                  id="pcc-email"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  inputMode="email"
+                  placeholder="you@firm.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  aria-invalid={gateStatus === "error" ? true : undefined}
+                  style={fieldStyle()}
+                />
+                <button className="btn btn--primary btn--sm" type="submit" disabled={gateStatus === "loading"}>
+                  {gateStatus === "loading" ? "Unlocking…" : "Get my full report"}
+                </button>
+              </div>
+              <div className="text-muted" style={{ fontSize: "0.8125rem", marginTop: 8 }} aria-live="polite">
+                {gateMessage ||
+                  (
+                    <>
+                      Also adds you to firm capacity updates. Unsubscribe anytime.{" "}
+                      <Link href="/privacy" className="text-muted" style={{ textDecoration: "underline" }}>
+                        Privacy
+                      </Link>
+                      .
+                    </>
+                  )}
+              </div>
+            </form>
+          ) : (
+            <div
+              className="card mt-4"
+              style={{ borderRadius: 12, padding: "1rem", background: "color-mix(in srgb, var(--bg2) 86%, #0ea5e9 14%)" }}
+            >
+              <div className="label" style={{ margin: 0 }}>
+                Full capacity report
+              </div>
+
+              <div className="mt-4" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 10 }}>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    Cases past capacity
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {Math.round(result.casesUnderServed)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    Paralegals needed to close the gap
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {result.staffingGap}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    New intakes / paralegal / month
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {result.intakeLoadPerPara.toFixed(1)}
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-muted" style={{ marginTop: 14, lineHeight: 1.55 }}>
+                {recommendation(result, practiceType)}
+              </p>
+
+              <div style={{ marginTop: 14, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <Link
+                  className="btn btn--primary btn--sm"
+                  href="/paralegals"
+                  onClick={() => trackToolCTA("/paralegals")}
+                >
+                  See how a Paralegal Team closes that gap
+                </Link>
+                <Link className="btn btn--secondary btn--sm" href="/tools" onClick={() => trackToolCTA("/tools")}>
+                  Browse the free tool directory
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="text-muted" style={{ marginTop: 14, fontSize: "0.82rem", lineHeight: 1.5 }}>
+        This calculator gives a directional read on paralegal capacity, not a staffing audit. Target caseloads are an
+        industry rule of thumb - actual capacity varies by case complexity, jurisdiction, and firm workflow.
+      </div>
+    </div>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -74,7 +74,8 @@ export function SiteHeader() {
       { href: "/tools/source-finder", label: "Source Finder" },
       { href: "/resources/open-legal-data-map", label: "US Data Map" },
       { href: "/tools/contract-qa-planner", label: "Contract QA Planner" },
-      { href: "/resources/contract-qa-pipeline-map", label: "Contract QA Map" }
+      { href: "/resources/contract-qa-pipeline-map", label: "Contract QA Map" },
+      { href: "/tools/paralegal-capacity-calculator", label: "Paralegal Capacity Calculator" }
     ],
     []
   );

--- a/lib/paralegal-capacity.ts
+++ b/lib/paralegal-capacity.ts
@@ -1,0 +1,150 @@
+/**
+ * Paralegal Capacity Calculator - data + pure scoring logic.
+ *
+ * Pure data and pure functions only. No React, no DOM, no side effects, so
+ * the whole module is unit-testable and can be imported by the server
+ * component to render the tool without depending on client-side state.
+ *
+ * The target caseload bands below are an industry rule of thumb, not a
+ * measured benchmark - every case type, jurisdiction, and firm workflow
+ * differs. The UI must label this as a starting point, adjustable per firm,
+ * never as hard data.
+ */
+
+export type PracticeType = "auto" | "premises" | "medmal" | "masstort" | "mixed";
+
+export type CapacityStatus = "green" | "amber" | "red";
+
+export interface CapacityInputs {
+  attorneys: number;
+  paralegals: number;
+  activeCases: number;
+  newIntakesPerMonth: number;
+  practiceType?: PracticeType;
+}
+
+export interface CapacityResult {
+  /** Active cases carried per paralegal at current staffing. */
+  casesPerParalegal: number;
+  /** Paralegals per attorney. Below 0.5 signals thin paralegal support regardless of caseload. */
+  attorneyRatio: number;
+  /** Target caseload per paralegal for the selected practice mix (rule of thumb). */
+  target: number;
+  /** Percent over (positive) or under (negative/zero) the target caseload. */
+  overloadPct: number;
+  /** New intakes per paralegal per month. */
+  intakeLoadPerPara: number;
+  status: CapacityStatus;
+  /** Active cases being carried past what the target caseload supports. */
+  casesUnderServed: number;
+  /** Additional paralegals needed to bring caseload back to the target. */
+  staffingGap: number;
+}
+
+export const DEFAULT_PRACTICE_TYPE: PracticeType = "mixed";
+
+/** Order mirrors how the options should appear in the UI. */
+export const PRACTICE_TYPES: PracticeType[] = ["mixed", "auto", "premises", "medmal", "masstort"];
+
+export const PRACTICE_TYPE_TARGETS: Record<PracticeType, number> = {
+  auto: 70,
+  premises: 60,
+  medmal: 35,
+  masstort: 40,
+  mixed: 50
+};
+
+export const PRACTICE_TYPE_LABELS: Record<PracticeType, string> = {
+  auto: "Auto accident",
+  premises: "Premises liability",
+  medmal: "Medical malpractice",
+  masstort: "Mass tort",
+  mixed: "Mixed / general PI"
+};
+
+export function practiceTypeLabel(practiceType: PracticeType): string {
+  return PRACTICE_TYPE_LABELS[practiceType];
+}
+
+export function practiceTypeTarget(practiceType: PracticeType): number {
+  return PRACTICE_TYPE_TARGETS[practiceType];
+}
+
+export function calculateCapacity(inputs: CapacityInputs): CapacityResult {
+  const practiceType = inputs.practiceType ?? DEFAULT_PRACTICE_TYPE;
+  const target = PRACTICE_TYPE_TARGETS[practiceType];
+
+  const paralegalsForDivision = Math.max(inputs.paralegals, 1);
+  const attorneysForDivision = Math.max(inputs.attorneys, 1);
+
+  const casesPerParalegal = inputs.activeCases / paralegalsForDivision;
+  const attorneyRatio = inputs.paralegals / attorneysForDivision;
+  const overloadPct = (casesPerParalegal / target - 1) * 100;
+  const intakeLoadPerPara = inputs.newIntakesPerMonth / paralegalsForDivision;
+
+  let status: CapacityStatus;
+  if (overloadPct > 40 || attorneyRatio < 0.5) {
+    status = "red";
+  } else if (overloadPct > 0) {
+    status = "amber";
+  } else {
+    status = "green";
+  }
+
+  const casesUnderServed = Math.max(0, inputs.activeCases - inputs.paralegals * target);
+  const staffingGap = Math.max(0, Math.ceil(inputs.activeCases / target) - inputs.paralegals);
+
+  return {
+    casesPerParalegal,
+    attorneyRatio,
+    target,
+    overloadPct,
+    intakeLoadPerPara,
+    status,
+    casesUnderServed,
+    staffingGap
+  };
+}
+
+export function statusLabel(status: CapacityStatus): string {
+  if (status === "green") return "Under capacity";
+  if (status === "amber") return "Approaching capacity";
+  return "Over capacity";
+}
+
+/**
+ * One-line, ungated verdict. Kept plain and numeric - no hype, no adjectives
+ * beyond what the numbers support.
+ */
+export function verdictSentence(result: CapacityResult): string {
+  const cases = Math.round(result.casesPerParalegal);
+  const overPct = Math.round(result.overloadPct);
+
+  if (result.overloadPct <= 0) {
+    const underPct = Math.abs(overPct);
+    return `Your paralegals carry about ${cases} active cases each, about ${underPct}% under the target caseload for this practice mix.`;
+  }
+
+  return `Your paralegals carry about ${cases} active cases each, about ${overPct}% over a manageable caseload.`;
+}
+
+/**
+ * Gated recommendation paragraph. Neutral, operator voice - states the gap in
+ * this firm's own numbers, then names the service that closes it without
+ * quoting price or claiming exclusivity.
+ */
+export function recommendation(result: CapacityResult, practiceType: PracticeType): string {
+  const label = practiceTypeLabel(practiceType).toLowerCase();
+
+  if (result.status === "green") {
+    return `At current staffing, this firm's paralegal caseload is within the industry rule of thumb for ${label} work. Keep watching intake volume as case count grows - the gap can open quickly after a busy quarter.`;
+  }
+
+  const underServed = Math.round(result.casesUnderServed);
+  const gapNote =
+    result.staffingGap > 0
+      ? ` Closing the gap fully would take roughly ${result.staffingGap} more paralegal${result.staffingGap === 1 ? "" : "s"} at this caseload target.`
+      : "";
+
+  return `At current staffing, about ${underServed} active case${underServed === 1 ? "" : "s"} are being carried past a manageable caseload for ${label} work.${gapNote} Paralegal Teams adds dedicated paralegal capacity sized to that gap, without a full-time hire.`;
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -22,6 +22,7 @@ Primary domain: https://counterbench.ai
 - Collections: https://counterbench.ai/tools/collections
 - Compare: https://counterbench.ai/tools/compare
 - Conflict Check Blind Spot Audit (free, 8 questions, answers "what is a law firm conflict check" and scores how reliably a firm's process catches conflicts): https://counterbench.ai/tools/conflict-check-audit
+- Paralegal Capacity Calculator (free, enter attorney/paralegal/case counts, scores whether a firm's paralegal function is over capacity): https://counterbench.ai/tools/paralegal-capacity-calculator
 - Prompts library: https://counterbench.ai/prompts
 - Prompt packs: https://counterbench.ai/prompts/packs
 - Playbooks: https://counterbench.ai/playbooks


### PR DESCRIPTION
## What
New free tool at `/tools/paralegal-capacity-calculator`. A PI firm enters attorneys, paralegals, active cases, and monthly intakes; gets a RAG read on whether its paralegal function is over capacity, then an email-gated full report that maps the gap to Paralegal Teams.

## Why
From the Aug 2 smoke-signals synthesis: paralegal frustration + firm understaffing was the strongest legal signal. This turns that pain into a scored diagnostic whose output (staffing gap) maps directly to the retainer service. Engineering-as-marketing: the free vendor-neutral directory + a lead tool feeding the human service.

## How it works
- **Ungated:** cases per paralegal, paralegals per attorney, RAG verdict.
- **Gated (email):** cases under-served, staffing gap to reach green, recommendation, CTA to `/paralegals`.
- Lead posts to the reused `/api/newsletter/subscribe` (extended with an optional, backward-compatible `meta` field) with `source=paralegal-capacity-calculator`.

## Math (lib/paralegal-capacity.ts, pure + tested)
```
casesPerParalegal = activeCases / max(paralegals,1)
attorneyRatio     = paralegals / max(attorneys,1)
overloadPct       = (casesPerParalegal/target - 1) * 100
status: red if overloadPct>40 OR attorneyRatio<0.5; amber if 0<overloadPct<=40; else green
casesUnderServed  = max(0, activeCases - paralegals*target)
staffingGap       = max(0, ceil(activeCases/target) - paralegals)
```
Caseload `target` by practice type: auto 70 / premises 60 / medmal 35 / masstort 40 / mixed 50 (default). **Labeled in-UI as rules of thumb, tunable** once real firm data lands. No dollar-at-risk in this MVP.

## Files
New: `lib/paralegal-capacity.ts`, `components/ParalegalCapacityCalculator.tsx`, `app/tools/paralegal-capacity-calculator/page.tsx`, `__tests__/paralegal-capacity.test.ts` (20 tests).
Additive: `app/api/newsletter/subscribe/route.ts` (optional meta, back-compat), `app/sitemap.ts`, `components/SiteHeader.tsx`, `public/llms.txt`.

## Verification
- `npm run typecheck` PASS · `npm run build` PASS (route static, 3.79 kB) · `npx vitest run __tests__` PASS (64 tests, 20 new)
- `npm run lint`: new files contribute 0 errors; remaining errors pre-exist on `main` (confirmed by stash).
- Desktop + mobile screenshots verified. 0 em-dashes, no price restated, directory-neutral, no moat line.

## Follow-up
Caseload bands are placeholder rules of thumb. Swap for validated numbers when firm data is available.