### PR TITLE
feat(tools): Intake Leak Calculator (free tool)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,6 +19,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/tools/contract-qa-planner"), lastModified: now, changeFrequency: "weekly", priority: 0.74 },
     { url: absoluteUrl("/tools/conflict-check-audit"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/paralegal-capacity-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
+    { url: absoluteUrl("/tools/intake-leak-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/guides"), lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: absoluteUrl("/about"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/contact"), lastModified: now, changeFrequency: "monthly", priority: 0.7 },

--- a/app/tools/intake-leak-calculator/page.tsx
+++ b/app/tools/intake-leak-calculator/page.tsx
@@ -1,0 +1,27 @@
+import { IntakeLeakCalculator } from "@/components/IntakeLeakCalculator";
+
+export const metadata = {
+  title: "Intake Leak Calculator",
+  description:
+    "Enter your monthly intake call volume, cost per call, and the share that never convert to see the dollars and paralegal hours your PI firm burns on tire-kicker calls each month."
+};
+
+export default function IntakeLeakCalculatorPage() {
+  return (
+    <main>
+      <section className="section" style={{ paddingTop: 108, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label">Free tool</div>
+          <h1 className="max-w-900">How much is your intake leaking?</h1>
+          <p className="max-w-800 mt-4" style={{ fontSize: "1.125rem" }}>
+            Most small firms treat intake as a phone problem and never count what the leak costs. Enter a few numbers
+            and see the dollars and paralegal hours you lose each month to calls that were never going to hire, then
+            unlock the full report.
+          </p>
+
+          <IntakeLeakCalculator />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/IntakeLeakCalculator.tsx
+++ b/components/IntakeLeakCalculator.tsx
@@ -1,0 +1,446 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  calculateIntakeLeak,
+  formatUSD,
+  recommendation,
+  statusLabel,
+  verdictSentence,
+  type IntakeInputs,
+  type IntakeStatus
+} from "@/lib/intake-leak";
+
+const TOOL_SLUG = "intake-leak-calculator";
+
+// Local dataLayer helpers. Event shapes mirror the tool_view / tool_click_cta
+// convention used by the other free tools in this repo (see
+// components/ParalegalCapacityCalculator.tsx); kept inline so this tool has no
+// cross-module dependency to ship.
+function pushEvent(event: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(event);
+}
+function trackToolView(): void {
+  pushEvent({ event: "tool_view", tool_slug: TOOL_SLUG });
+}
+function trackToolCTA(destination: string): void {
+  pushEvent({ event: "tool_click_cta", tool_slug: TOOL_SLUG, destination });
+}
+
+const STATUS_COLOR: Record<IntakeStatus, string> = {
+  green: "var(--green)",
+  amber: "var(--amber)",
+  red: "var(--red)"
+};
+
+function toNonNegativeNumber(raw: string): number {
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return n;
+}
+
+function isValidEmail(email: string): boolean {
+  const e = email.trim();
+  if (e.length < 5 || e.length > 254) return false;
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(e);
+}
+
+function fieldStyle(): React.CSSProperties {
+  return {
+    width: "100%",
+    padding: "12px 14px",
+    borderRadius: 999,
+    border: "1px solid var(--border)",
+    background: "var(--input-bg)",
+    color: "var(--fg)"
+  };
+}
+
+export function IntakeLeakCalculator() {
+  const [callsRaw, setCallsRaw] = useState("120");
+  const [costRaw, setCostRaw] = useState("30");
+  const [shareRaw, setShareRaw] = useState("80");
+  const [minutesRaw, setMinutesRaw] = useState("12");
+  const [paraRateRaw, setParaRateRaw] = useState("35");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [caseValueRaw, setCaseValueRaw] = useState("");
+
+  const [email, setEmail] = useState("");
+  const [unlocked, setUnlocked] = useState(false);
+  const [gateStatus, setGateStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [gateMessage, setGateMessage] = useState("");
+
+  useEffect(() => {
+    trackToolView();
+  }, []);
+
+  const inputs: IntakeInputs = useMemo(
+    () => ({
+      callsPerMonth: toNonNegativeNumber(callsRaw),
+      costPerCall: toNonNegativeNumber(costRaw),
+      shareNeverConvertPct: toNonNegativeNumber(shareRaw),
+      minutesPerCall: toNonNegativeNumber(minutesRaw),
+      paralegalCostPerHour: toNonNegativeNumber(paraRateRaw),
+      avgCaseValue: toNonNegativeNumber(caseValueRaw),
+      currentSignRatePct: 0
+    }),
+    [callsRaw, costRaw, shareRaw, minutesRaw, paraRateRaw, caseValueRaw]
+  );
+
+  const result = useMemo(() => calculateIntakeLeak(inputs), [inputs]);
+  const hasEnoughInput = inputs.callsPerMonth > 0 && inputs.shareNeverConvertPct > 0;
+
+  async function handleUnlock(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (!isValidEmail(email)) {
+      setGateStatus("error");
+      setGateMessage("Enter a valid email.");
+      return;
+    }
+
+    setGateStatus("loading");
+    setGateMessage("");
+
+    try {
+      const res = await fetch("/api/newsletter/subscribe", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          source: TOOL_SLUG,
+          meta: {
+            tool: TOOL_SLUG,
+            calls_per_month: inputs.callsPerMonth,
+            cost_per_call: inputs.costPerCall,
+            share_never_convert_pct: inputs.shareNeverConvertPct,
+            minutes_per_call: inputs.minutesPerCall,
+            paralegal_cost_per_hour: inputs.paralegalCostPerHour,
+            avg_case_value: inputs.avgCaseValue,
+            monthly_leak: Math.round(result.monthlyLeak),
+            annual_leak: Math.round(result.annualLeak),
+            wasted_hours: Math.round(result.wastedHours * 10) / 10,
+            status: result.status
+          }
+        })
+      });
+
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; message?: string };
+
+      if (!res.ok || !data.ok) {
+        setGateStatus("error");
+        setGateMessage(data.message || "Could not unlock the report. Try again in a moment.");
+        return;
+      }
+
+      setUnlocked(true);
+      setGateStatus("idle");
+      pushEvent({ event: "intake_leak_lead", tool_slug: TOOL_SLUG, status: result.status });
+    } catch {
+      setGateStatus("error");
+      setGateMessage("Network error. Please try again.");
+    }
+  }
+
+  return (
+    <div className="mt-5">
+      <div
+        className="card"
+        style={{
+          borderRadius: 18,
+          border: "1px solid color-mix(in srgb, var(--border) 68%, #0ea5e9 32%)",
+          background:
+            "linear-gradient(160deg, color-mix(in srgb, #111827 84%, #0c4a6e 16%) 0%, color-mix(in srgb, #020617 90%, #0f172a 10%) 100%)"
+        }}
+      >
+        <div className="label">Free tool</div>
+        <div className="text-white" style={{ fontSize: "1.9rem", fontWeight: 850, lineHeight: 1.1, letterSpacing: "-0.03em" }}>
+          Intake Leak Calculator
+        </div>
+        <p className="text-muted" style={{ marginTop: 10, maxWidth: 820, fontSize: "1.03rem", lineHeight: 1.55 }}>
+          Enter your intake numbers to see the dollars and paralegal hours your firm burns each month on calls that
+          never become clients.
+        </p>
+
+        <div
+          className="mt-5"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(190px, 1fr))",
+            gap: 10,
+            alignItems: "end"
+          }}
+        >
+          <div>
+            <label className="label" htmlFor="ilc-calls">
+              Intake calls / month
+            </label>
+            <input
+              id="ilc-calls"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={callsRaw}
+              onChange={(e) => setCallsRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="ilc-cost">
+              Cost / call ($)
+            </label>
+            <input
+              id="ilc-cost"
+              type="number"
+              min={0}
+              inputMode="decimal"
+              value={costRaw}
+              onChange={(e) => setCostRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="ilc-share">
+              % that never convert
+            </label>
+            <input
+              id="ilc-share"
+              type="number"
+              min={0}
+              max={100}
+              inputMode="numeric"
+              value={shareRaw}
+              onChange={(e) => setShareRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="ilc-minutes">
+              Paralegal min / call
+            </label>
+            <input
+              id="ilc-minutes"
+              type="number"
+              min={0}
+              inputMode="numeric"
+              value={minutesRaw}
+              onChange={(e) => setMinutesRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+
+          <div>
+            <label className="label" htmlFor="ilc-para-rate">
+              Paralegal $ / hour
+            </label>
+            <input
+              id="ilc-para-rate"
+              type="number"
+              min={0}
+              inputMode="decimal"
+              value={paraRateRaw}
+              onChange={(e) => setParaRateRaw(e.target.value)}
+              style={fieldStyle()}
+            />
+          </div>
+        </div>
+
+        <div style={{ marginTop: 12 }}>
+          <button
+            type="button"
+            className="text-muted"
+            onClick={() => setShowAdvanced((v) => !v)}
+            style={{ background: "none", border: "none", padding: 0, cursor: "pointer", fontSize: "0.82rem", textDecoration: "underline" }}
+            aria-expanded={showAdvanced}
+          >
+            {showAdvanced ? "Hide" : "Add"} average case value to model recovered revenue
+          </button>
+          {showAdvanced ? (
+            <div style={{ marginTop: 10, maxWidth: 260 }}>
+              <label className="label" htmlFor="ilc-case-value">
+                Avg case value ($)
+              </label>
+              <input
+                id="ilc-case-value"
+                type="number"
+                min={0}
+                inputMode="decimal"
+                placeholder="e.g. 8000"
+                value={caseValueRaw}
+                onChange={(e) => setCaseValueRaw(e.target.value)}
+                style={fieldStyle()}
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="text-muted" style={{ marginTop: 12, fontSize: "0.8125rem", lineHeight: 1.5 }}>
+          Referral firm with no per-call cost? Set cost / call to 0 and the leak runs on paralegal hours alone. These
+          are your numbers, not a benchmark - adjust them to your firm.
+        </div>
+      </div>
+
+      {!hasEnoughInput ? (
+        <div className="card mt-4" style={{ borderRadius: 16 }}>
+          <div className="text-muted">Enter your monthly call volume and the share that never convert to see your leak.</div>
+        </div>
+      ) : (
+        <div className="card mt-4" style={{ borderRadius: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+              <span
+                aria-hidden="true"
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: STATUS_COLOR[result.status]
+                }}
+              />
+              <div>
+                <div className="label" style={{ margin: 0 }}>
+                  {statusLabel(result.status)}
+                </div>
+                <div className="text-white" style={{ fontWeight: 800, fontSize: "1.6rem", letterSpacing: "-0.02em" }}>
+                  {formatUSD(result.monthlyLeak)} / month leaking
+                </div>
+                <div className="text-muted" style={{ fontSize: "0.9rem" }}>
+                  {formatUSD(result.annualLeak)} / year &middot; {result.workdaysLostPerMonth.toFixed(1)} paralegal workdays / month
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-muted" style={{ marginTop: 12, lineHeight: 1.55, fontSize: "1.03rem" }}>
+            {verdictSentence(result)}
+          </p>
+
+          {!unlocked ? (
+            <form
+              onSubmit={handleUnlock}
+              style={{
+                marginTop: 16,
+                padding: "14px 16px",
+                borderRadius: 12,
+                background: "color-mix(in srgb, var(--bg2) 90%, #0ea5e9 10%)",
+                border: "1px solid var(--border)"
+              }}
+            >
+              <div className="text-white" style={{ fontWeight: 700, fontSize: "0.95rem", marginBottom: 6 }}>
+                Unlock the full leak report
+              </div>
+              <div className="text-muted" style={{ fontSize: "0.82rem", marginBottom: 10, lineHeight: 1.45 }}>
+                See the annual leak, the paralegal time a screening layer reclaims, and where the fix pays for itself.
+              </div>
+              <div className="flex flex--gap-2 flex--resp-col" style={{ maxWidth: 460 }}>
+                <label className="sr-only" htmlFor="ilc-email">
+                  Email
+                </label>
+                <input
+                  id="ilc-email"
+                  type="email"
+                  required
+                  autoComplete="email"
+                  inputMode="email"
+                  placeholder="you@firm.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  aria-invalid={gateStatus === "error" ? true : undefined}
+                  style={fieldStyle()}
+                />
+                <button className="btn btn--primary btn--sm" type="submit" disabled={gateStatus === "loading"}>
+                  {gateStatus === "loading" ? "Unlocking…" : "Get my full report"}
+                </button>
+              </div>
+              <div className="text-muted" style={{ fontSize: "0.8125rem", marginTop: 8 }} aria-live="polite">
+                {gateMessage ||
+                  (
+                    <>
+                      Also adds you to firm intake updates. Unsubscribe anytime.{" "}
+                      <Link href="/privacy" className="text-muted" style={{ textDecoration: "underline" }}>
+                        Privacy
+                      </Link>
+                      .
+                    </>
+                  )}
+              </div>
+            </form>
+          ) : (
+            <div
+              className="card mt-4"
+              style={{ borderRadius: 12, padding: "1rem", background: "color-mix(in srgb, var(--bg2) 86%, #0ea5e9 14%)" }}
+            >
+              <div className="label" style={{ margin: 0 }}>
+                Full leak report
+              </div>
+
+              <div className="mt-4" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))", gap: 10 }}>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    Annual leak
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {formatUSD(result.annualLeak)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    Paralegal time reclaimed / month
+                    <span title="Modeled: a screening layer is assumed to give back ~60% of dead-call time. Conservative, not guaranteed." style={{ cursor: "help" }}>
+                      {" "}&#9432;
+                    </span>
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {formatUSD(result.recoverableLaborDollars)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted" style={{ fontSize: "0.82rem" }}>
+                    {result.hasRecoveryModel ? "Signed-case value recovered / month" : "Wasted paralegal hours / month"}
+                    {result.hasRecoveryModel ? (
+                      <span title="Modeled: a trained team is assumed to convert a small share of workable 'maybe' calls. Conservative, not guaranteed." style={{ cursor: "help" }}>
+                        {" "}&#9432;
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-white" style={{ fontWeight: 800, fontSize: "1.4rem" }}>
+                    {result.hasRecoveryModel ? formatUSD(result.recoveredRevenue) : result.wastedHours.toFixed(0)}
+                  </div>
+                </div>
+              </div>
+
+              <p className="text-muted" style={{ marginTop: 14, lineHeight: 1.55 }}>
+                {recommendation(result)}
+              </p>
+
+              <div style={{ marginTop: 14, display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <Link
+                  className="btn btn--primary btn--sm"
+                  href="/paralegals"
+                  onClick={() => trackToolCTA("/paralegals")}
+                >
+                  See what a Paralegal Team costs vs. your leak
+                </Link>
+                <Link className="btn btn--secondary btn--sm" href="/tools" onClick={() => trackToolCTA("/tools")}>
+                  Browse the free tool directory
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="text-muted" style={{ marginTop: 14, fontSize: "0.82rem", lineHeight: 1.5 }}>
+        This calculator gives a directional read on intake leak, not an audit. The recovery figures are modeled and
+        conservative, not a promise - actual results vary by case mix, source quality, and how intake is run.
+      </div>
+    </div>
+  );
+}

--- a/components/SiteHeader.tsx
+++ b/components/SiteHeader.tsx
@@ -75,7 +75,8 @@ export function SiteHeader() {
       { href: "/resources/open-legal-data-map", label: "US Data Map" },
       { href: "/tools/contract-qa-planner", label: "Contract QA Planner" },
       { href: "/resources/contract-qa-pipeline-map", label: "Contract QA Map" },
-      { href: "/tools/paralegal-capacity-calculator", label: "Paralegal Capacity Calculator" }
+      { href: "/tools/paralegal-capacity-calculator", label: "Paralegal Capacity Calculator" },
+      { href: "/tools/intake-leak-calculator", label: "Intake Leak Calculator" }
     ],
     []
   );

--- a/lib/intake-leak.ts
+++ b/lib/intake-leak.ts
@@ -1,0 +1,136 @@
+// Intake Leak Calculator — pure calculation logic.
+// Mirrors the shape of lib/paralegal-capacity.ts: types + pure functions, no React.
+// A firm enters its intake volume and cost; this returns the dollars and paralegal
+// hours it burns each month on calls that never become clients, then frames that
+// number as the budget for a screening + paralegal-team fix.
+
+export interface IntakeInputs {
+  callsPerMonth: number;
+  costPerCall: number; // USD per inbound intake call (LSA/PPC blended); 0 for referral firms
+  shareNeverConvertPct: number; // 0-100, share of calls that never become clients
+  minutesPerCall: number; // paralegal minutes spent per dead call (screen + notes + follow-up)
+  paralegalCostPerHour: number; // loaded cost per hour
+  // Optional advanced inputs for the modeled-recovery line. 0 = omit.
+  avgCaseValue: number;
+  currentSignRatePct: number; // 0-100
+}
+
+export type IntakeStatus = "green" | "amber" | "red";
+
+export interface IntakeResult {
+  wastedCalls: number;
+  wastedAdDollars: number;
+  wastedHours: number;
+  wastedLaborDollars: number;
+  monthlyLeak: number;
+  annualLeak: number;
+  workdaysLostPerMonth: number;
+  // Modeled, conservative recovery (labeled as such in the UI).
+  recoverableLaborDollars: number;
+  recoveredRevenue: number; // 0 unless avgCaseValue provided
+  status: IntakeStatus;
+  hasRecoveryModel: boolean;
+}
+
+// Conservative recovery multipliers. Surfaced on hover in the UI; never presented
+// as guaranteed. A screening + trained-team layer is modeled to reclaim ~60% of
+// dead-call time and lift the signed-case count off the "maybes" it works properly.
+export const RECOVERY = {
+  laborReclaimRate: 0.6, // share of dead-call hours a screening layer gives back
+  maybeShareOfCalls: 0.15, // share of calls that are workable "maybes"
+  signRateLift: 0.1 // extra conversion on those maybes with a trained team
+} as const;
+
+// Red once the monthly leak clears a paralegal-team retainer floor ($3,750/mo):
+// at that point the leak itself is the budget for the fix. Amber is a real but
+// sub-retainer leak; green is a modest one.
+const RED_FLOOR = 3750;
+const AMBER_FLOOR = 1000;
+
+function clampPct(pct: number): number {
+  if (!Number.isFinite(pct) || pct < 0) return 0;
+  if (pct > 100) return 100;
+  return pct;
+}
+
+function nonNeg(n: number): number {
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+export function calculateIntakeLeak(input: IntakeInputs): IntakeResult {
+  const calls = nonNeg(input.callsPerMonth);
+  const costPerCall = nonNeg(input.costPerCall);
+  const share = clampPct(input.shareNeverConvertPct) / 100;
+  const minutes = nonNeg(input.minutesPerCall);
+  const paraRate = nonNeg(input.paralegalCostPerHour);
+  const avgCaseValue = nonNeg(input.avgCaseValue);
+
+  const wastedCalls = calls * share;
+  const wastedAdDollars = wastedCalls * costPerCall;
+  const wastedHours = (wastedCalls * minutes) / 60;
+  const wastedLaborDollars = wastedHours * paraRate;
+  const monthlyLeak = wastedAdDollars + wastedLaborDollars;
+  const annualLeak = monthlyLeak * 12;
+  const workdaysLostPerMonth = wastedHours / 8;
+
+  const recoverableLaborDollars = wastedHours * RECOVERY.laborReclaimRate * paraRate;
+
+  const hasRecoveryModel = avgCaseValue > 0;
+  const extraCasesPerMonth = calls * RECOVERY.maybeShareOfCalls * RECOVERY.signRateLift;
+  const recoveredRevenue = hasRecoveryModel ? extraCasesPerMonth * avgCaseValue : 0;
+
+  let status: IntakeStatus = "green";
+  if (monthlyLeak >= RED_FLOOR) status = "red";
+  else if (monthlyLeak >= AMBER_FLOOR) status = "amber";
+
+  return {
+    wastedCalls,
+    wastedAdDollars,
+    wastedHours,
+    wastedLaborDollars,
+    monthlyLeak,
+    annualLeak,
+    workdaysLostPerMonth,
+    recoverableLaborDollars,
+    recoveredRevenue,
+    status,
+    hasRecoveryModel
+  };
+}
+
+export function statusLabel(status: IntakeStatus): string {
+  switch (status) {
+    case "green":
+      return "Contained leak";
+    case "amber":
+      return "Real leak";
+    case "red":
+      return "Retainer-sized leak";
+  }
+}
+
+export function formatUSD(n: number): string {
+  const rounded = Math.round(nonNeg(n));
+  return "$" + rounded.toLocaleString("en-US");
+}
+
+export function verdictSentence(r: IntakeResult): string {
+  const leak = formatUSD(r.monthlyLeak);
+  const days = r.workdaysLostPerMonth.toFixed(1);
+  if (r.status === "red") {
+    return `Your firm burns about ${leak} a month on calls that never become clients, and roughly ${days} paralegal workdays with them. That is more than a paralegal team costs. The leak is the budget for the fix.`;
+  }
+  if (r.status === "amber") {
+    return `Your firm loses about ${leak} a month to intake that goes nowhere, plus roughly ${days} paralegal workdays. Not fatal, but it is a real line item hiding as "just how intake works."`;
+  }
+  return `Your intake leak runs about ${leak} a month and roughly ${days} paralegal workdays. Modest today. Worth watching as your call volume grows, because the leak scales with it.`;
+}
+
+export function recommendation(r: IntakeResult): string {
+  const reclaim = formatUSD(r.recoverableLaborDollars);
+  const base = `Intake is a triage problem, not a phone problem. Software screens the obvious noise; a trained paralegal works the maybes in the middle. Run both layers and a conservative model reclaims about ${reclaim} of paralegal time a month`;
+  if (r.hasRecoveryModel && r.recoveredRevenue > 0) {
+    return `${base}, plus roughly ${formatUSD(r.recoveredRevenue)} in signed-case value that today slips through mishandled calls. Modeled, not guaranteed. The point is the number is big enough to fund a better system.`;
+  }
+  return `${base}. Add your average case value to model the signed cases you recover on top of that. The point is the leak is usually big enough to fund a better system.`;
+}


### PR DESCRIPTION
New free lead-gen calculator for PI firms, mirroring the `paralegal-capacity-calculator` pattern.

**Count the leak before you fix it** — firm enters calls/month, cost/call, % that never convert, paralegal min/call, paralegal $/hr → live monthly + annual leak and paralegal workdays lost. Optional avg case value models recovered revenue. Email gate → full report → CTA to /paralegals.

- Pure calc in `lib/intake-leak.ts`; client component mirrors ParalegalCapacityCalculator; gate posts to `/api/newsletter/subscribe`.
- Registered in SiteHeader nav + sitemap.
- Recovery figures labeled modeled/conservative (no over-promise).
- Verified: renders on-brand, calc exact (defaults → $3,552/mo, $42,624/yr, 2.4 workdays), gate handles errors without false-unlock, tsc clean, no console errors.