### PR TITLE
feat(tools): add law firm stack cost calculator

### DIFF
--- a/__tests__/law-firm-stack-cost.test.ts
+++ b/__tests__/law-firm-stack-cost.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { calculateStackCost, type StackCostInputs } from "@/lib/law-firm-stack-cost";
+
+function inputs(overrides: Partial<StackCostInputs> = {}): StackCostInputs {
+  return {
+    monthlySoftwareCost: 1_000,
+    setupHours: 10,
+    monthlyMaintenanceHours: 2,
+    ownerRole: "operations",
+    ownerHourlyValue: 100,
+    disruptionsPerQuarter: 1,
+    hoursLostPerDisruption: 2,
+    ...overrides,
+  };
+}
+
+describe("calculateStackCost", () => {
+  it("calculates first-year, recurring, and three-year ownership cost", () => {
+    const result = calculateStackCost(inputs());
+
+    expect(result.annualLicenseCost).toBe(12_000);
+    expect(result.setupLaborCost).toBe(1_000);
+    expect(result.annualMaintenanceCost).toBe(2_400);
+    expect(result.annualDowntimeCost).toBe(800);
+    expect(result.hiddenLaborCost).toBe(4_200);
+    expect(result.recurringAnnualCost).toBe(15_200);
+    expect(result.firstYearCost).toBe(16_200);
+    expect(result.threeYearCost).toBe(46_600);
+    expect(result.firstYearOperatorHours).toBe(42);
+    expect(result.recurringOperatorHours).toBe(32);
+    expect(result.dominantCostDriver).toBe("software");
+    expect(result.verdict.key).toBe("keep");
+  });
+
+  it("recommends handing off when an attorney owns material recurring work", () => {
+    const result = calculateStackCost(
+      inputs({
+        monthlySoftwareCost: 2_000,
+        setupHours: 0,
+        monthlyMaintenanceHours: 6,
+        ownerRole: "managing-attorney",
+        ownerHourlyValue: 350,
+        disruptionsPerQuarter: 0,
+        hoursLostPerDisruption: 0,
+      }),
+    );
+
+    expect(result.recurringOperatorHours).toBe(72);
+    expect(result.verdict.key).toBe("hand-off");
+  });
+
+  it("recommends simplifying when recurring labor outweighs software", () => {
+    const result = calculateStackCost(
+      inputs({
+        monthlySoftwareCost: 500,
+        setupHours: 0,
+        monthlyMaintenanceHours: 12,
+        ownerRole: "operations",
+        ownerHourlyValue: 75,
+        disruptionsPerQuarter: 0,
+        hoursLostPerDisruption: 0,
+      }),
+    );
+
+    expect(result.recurringLaborShare).toBeGreaterThan(0.5);
+    expect(result.verdict.key).toBe("simplify");
+  });
+
+  it("recommends replacing the weak link when disruptions are material", () => {
+    const result = calculateStackCost(
+      inputs({
+        monthlySoftwareCost: 2_000,
+        setupHours: 0,
+        monthlyMaintenanceHours: 2,
+        ownerHourlyValue: 300,
+        disruptionsPerQuarter: 4,
+        hoursLostPerDisruption: 4,
+      }),
+    );
+
+    expect(result.annualDowntimeHours).toBe(64);
+    expect(result.annualDowntimeCost).toBe(19_200);
+    expect(result.verdict.key).toBe("replace-weak-link");
+  });
+
+  it("treats negative and non-finite numeric inputs as zero", () => {
+    const result = calculateStackCost(
+      inputs({
+        monthlySoftwareCost: -100,
+        setupHours: Number.POSITIVE_INFINITY,
+        monthlyMaintenanceHours: -1,
+        ownerHourlyValue: -50,
+        disruptionsPerQuarter: Number.NaN,
+        hoursLostPerDisruption: -2,
+      }),
+    );
+
+    expect(result.firstYearCost).toBe(0);
+    expect(result.threeYearCost).toBe(0);
+    expect(result.hiddenLaborShare).toBe(0);
+    expect(result.verdict.key).toBe("keep");
+  });
+});

--- a/app/(marketing)/resources/page.tsx
+++ b/app/(marketing)/resources/page.tsx
@@ -37,7 +37,26 @@ export default function ResourcesPage() {
             This view is intentionally filtered to US-focused legal resources and US-ready implementation patterns.
           </p>
 
-          <div className="grid grid--2 mt-5" style={{ gap: "1rem" }}>
+          <div className="grid grid--3 mt-5" style={{ gap: "1rem" }}>
+            <Link
+              href="/tools/law-firm-stack-cost-calculator"
+              className="card"
+              style={{
+                textDecoration: "none",
+                borderRadius: 16,
+                background:
+                  "linear-gradient(145deg, color-mix(in srgb, #14b8a6 24%, #020617 76%) 0%, color-mix(in srgb, #020617 86%, #0f172a 14%) 100%)"
+              }}
+            >
+              <div className="label">Free tool</div>
+              <div className="text-white" style={{ fontSize: "1.2rem", fontWeight: 800, letterSpacing: "-0.02em" }}>
+                Law firm tech stack cost calculator
+              </div>
+              <div className="text-muted" style={{ marginTop: 8 }}>
+                Calculate the true cost of licenses, maintenance, attorney time, and disruptions.
+              </div>
+            </Link>
+
             <Link
               href="/tools/source-finder"
               className="card"

--- a/app/api/stack-cost-report/route.ts
+++ b/app/api/stack-cost-report/route.ts
@@ -1,0 +1,222 @@
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+import {
+  calculateStackCost,
+  type StackCostInputs,
+  type StackOwnerRole,
+} from "@/lib/law-firm-stack-cost";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const ipHits = new Map<string, number[]>();
+const OWNER_ROLES: StackOwnerRole[] = [
+  "managing-attorney",
+  "attorney",
+  "paralegal",
+  "operations",
+  "external",
+];
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const hits = (ipHits.get(ip) ?? []).filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS);
+  if (hits.length >= RATE_LIMIT_MAX) {
+    ipHits.set(ip, hits);
+    return true;
+  }
+  hits.push(now);
+  ipHits.set(ip, hits);
+  return false;
+}
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, hits] of ipHits) {
+    const active = hits.filter((timestamp) => now - timestamp < RATE_LIMIT_WINDOW_MS);
+    if (active.length === 0) ipHits.delete(ip);
+    else ipHits.set(ip, active);
+  }
+}, 10 * 60 * 1000).unref();
+
+function getClientIp(request: Request): string {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0]?.trim() || "unknown";
+  return request.headers.get("x-real-ip") ?? "unknown";
+}
+
+function validEmail(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= 254 &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+  );
+}
+
+function boundedNumber(value: unknown, max: number): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= max ? value : null;
+}
+
+function parseInputs(value: unknown): StackCostInputs | null {
+  if (!value || typeof value !== "object") return null;
+  const input = value as Record<string, unknown>;
+  const ownerRole = input.ownerRole;
+  if (typeof ownerRole !== "string" || !OWNER_ROLES.includes(ownerRole as StackOwnerRole)) return null;
+
+  const monthlySoftwareCost = boundedNumber(input.monthlySoftwareCost, 10_000_000);
+  const setupHours = boundedNumber(input.setupHours, 100_000);
+  const monthlyMaintenanceHours = boundedNumber(input.monthlyMaintenanceHours, 10_000);
+  const ownerHourlyValue = boundedNumber(input.ownerHourlyValue, 100_000);
+  const disruptionsPerQuarter = boundedNumber(input.disruptionsPerQuarter, 10_000);
+  const hoursLostPerDisruption = boundedNumber(input.hoursLostPerDisruption, 100_000);
+
+  if (
+    monthlySoftwareCost === null ||
+    setupHours === null ||
+    monthlyMaintenanceHours === null ||
+    ownerHourlyValue === null ||
+    disruptionsPerQuarter === null ||
+    hoursLostPerDisruption === null
+  ) {
+    return null;
+  }
+
+  return {
+    monthlySoftwareCost,
+    setupHours,
+    monthlyMaintenanceHours,
+    ownerRole: ownerRole as StackOwnerRole,
+    ownerHourlyValue,
+    disruptionsPerQuarter,
+    hoursLostPerDisruption,
+  };
+}
+
+function dollars(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+async function forwardLead(payload: Record<string, unknown>) {
+  const url = process.env.N8N_LEAD_WEBHOOK_URL;
+  if (!url) return;
+
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch (error) {
+    console.error({ event: "stack_cost_n8n_forward_failed", error: String(error) });
+  }
+}
+
+export async function POST(request: Request) {
+  if (isRateLimited(getClientIp(request))) {
+    return NextResponse.json(
+      { message: "Too many email requests. Print or save this page, or try again later." },
+      { status: 429 },
+    );
+  }
+
+  const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) {
+    return NextResponse.json({ message: "The breakdown couldn't be sent. Try again." }, { status: 400 });
+  }
+
+  if (typeof body.company === "string" && body.company.trim()) {
+    return NextResponse.json({ ok: true });
+  }
+
+  if (!validEmail(body.email)) {
+    return NextResponse.json({ message: "Enter a valid work email." }, { status: 400 });
+  }
+
+  const inputs = parseInputs(body.inputs);
+  if (!inputs) {
+    return NextResponse.json(
+      { message: "The calculation details couldn't be read. Calculate the result again and retry." },
+      { status: 400 },
+    );
+  }
+
+  const email = body.email.trim();
+  const result = calculateStackCost(inputs);
+
+  await forwardLead({
+    business: "CounterbenchAI",
+    cta: "Law firm stack cost report",
+    source: "law-firm-stack-cost-calculator",
+    email,
+    verdict: result.verdict.key,
+    first_year_cost: Math.round(result.firstYearCost),
+    recurring_annual_cost: Math.round(result.recurringAnnualCost),
+    three_year_cost: Math.round(result.threeYearCost),
+    hidden_labor_share: Math.round(result.hiddenLaborShare * 100),
+    owner_role: inputs.ownerRole,
+    dominant_cost_driver: result.dominantCostDriver,
+  });
+
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error({ event: "stack_cost_report_no_resend_key" });
+    return NextResponse.json(
+      { message: "Email delivery is temporarily unavailable. Print or save this page instead." },
+      { status: 503 },
+    );
+  }
+
+  const text = [
+    "Your law firm tech stack cost breakdown",
+    "",
+    `First-year ownership cost: ${dollars(result.firstYearCost)}`,
+    `Recurring annual cost: ${dollars(result.recurringAnnualCost)}`,
+    `Three-year cost: ${dollars(result.threeYearCost)}`,
+    `Hidden labor: ${dollars(result.hiddenLaborCost)} (${Math.round(result.hiddenLaborShare * 100)}% of first-year cost)`,
+    `First-year operator time: ${Math.round(result.firstYearOperatorHours)} hours`,
+    "",
+    `Verdict: ${result.verdict.title}`,
+    result.verdict.summary,
+    "",
+    "Next three actions:",
+    ...result.verdict.actions.map((action, index) => `${index + 1}. ${action}`),
+    "",
+    "First-year cost breakdown:",
+    `Software licenses: ${dollars(result.annualLicenseCost)}`,
+    `Build and migration time: ${dollars(result.setupLaborCost)}`,
+    `Ongoing maintenance: ${dollars(result.annualMaintenanceCost)}`,
+    `Disruptions: ${dollars(result.annualDowntimeCost)}`,
+    "",
+    "Review the stack with Counterbench Advisory:",
+    "https://counterbench.ai/advisory?from=stack-cost-report",
+    "",
+    "This estimate uses the hourly value entered in the calculator. It isn't an accounting valuation or a recommendation to buy or replace any specific product.",
+  ].join("\n");
+
+  try {
+    const resend = new Resend(apiKey);
+    const response = await resend.emails.send({
+      from: process.env.RESEND_FROM || "Counterbench.AI <noreply@counterbench.ai>",
+      to: email,
+      subject: `Your law firm tech stack cost: ${dollars(result.firstYearCost)} in year one`,
+      text,
+    });
+
+    if (response.error) throw new Error(response.error.message);
+  } catch (error) {
+    console.error({ event: "stack_cost_report_send_failed", error: String(error) });
+    return NextResponse.json(
+      { message: "The breakdown couldn't be sent. Print or save this page instead." },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1015,3 +1015,309 @@ html[data-theme="light"] .ws-earlybird {
     display: none !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Law firm tech stack cost calculator
+   (/tools/law-firm-stack-cost-calculator)
+--------------------------------------------------------------------------- */
+.scc {
+  margin-top: 2rem;
+}
+.scc-proof-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+.scc-proof-row span {
+  padding: 0.5rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2);
+  background: var(--input-bg);
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+.scc-form {
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+.scc-form h2,
+.scc-email h3,
+.scc-cta h3 {
+  margin: 0.45rem 0 0.5rem;
+}
+.scc-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+.scc-fields > label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: var(--fg);
+  font-weight: 600;
+}
+.scc-fields small {
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.45;
+}
+.scc-fields input,
+.scc-fields select,
+.scc-email input[type="email"] {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--input-bg);
+  color: var(--fg);
+  padding: 0.8rem 0.9rem;
+  font: inherit;
+}
+.scc-fields input::placeholder,
+.scc-email input::placeholder {
+  color: var(--muted-2);
+}
+.scc-input-affix,
+.scc-input-suffix {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--input-bg);
+  color: var(--muted);
+  padding: 0 0.8rem;
+  font-weight: 400;
+}
+.scc-input-affix input,
+.scc-input-suffix input {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding-inline: 0;
+  outline-offset: 6px;
+}
+.scc-input-suffix span:last-child {
+  flex: 0 0 auto;
+  font-size: 0.82rem;
+}
+.scc-form-actions,
+.scc-result-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+}
+.scc-result {
+  scroll-margin-top: 6rem;
+  margin-top: 2rem;
+}
+.scc-result-hero {
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background:
+    radial-gradient(circle at 90% 10%, rgba(45, 212, 191, 0.13), transparent 42%),
+    var(--bg2);
+}
+.scc-total-label {
+  margin: 0.65rem 0 0;
+  color: var(--muted);
+}
+.scc-total {
+  margin: 0.25rem 0 0;
+  font-family: var(--serif);
+  font-size: clamp(2.75rem, 8vw, 5.25rem);
+  line-height: 0.95;
+  color: var(--fg);
+  letter-spacing: -0.045em;
+}
+.scc-verdict {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  max-width: 760px;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--border);
+}
+.scc-verdict h2,
+.scc-verdict p {
+  margin: 0;
+}
+.scc-verdict p {
+  margin-top: 0.4rem;
+}
+.scc-verdict-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  margin-top: 0.55rem;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--muted);
+  box-shadow: 0 0 0 5px rgba(148, 163, 184, 0.12);
+}
+.scc-verdict-dot--keep {
+  background: #22c55e;
+}
+.scc-verdict-dot--simplify {
+  background: #f59e0b;
+}
+.scc-verdict-dot--hand-off {
+  background: #38bdf8;
+}
+.scc-verdict-dot--replace-weak-link {
+  background: #f97316;
+}
+.scc-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+.scc-metrics .card {
+  padding: 1.2rem;
+}
+.scc-metrics strong {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--fg);
+  font-family: var(--serif);
+  font-size: 1.35rem;
+  line-height: 1.15;
+}
+.scc-metrics p {
+  margin: 0.5rem 0 0;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.scc-cost-list,
+.scc-formula {
+  margin: 1rem 0 0;
+}
+.scc-cost-list > div,
+.scc-formula > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.scc-cost-list > div:last-child,
+.scc-formula > div:last-child {
+  border-bottom: 0;
+}
+.scc-cost-list dd,
+.scc-formula dd {
+  margin: 0;
+  text-align: right;
+  color: var(--fg);
+  font-weight: 600;
+}
+.scc-formula dt {
+  color: var(--muted);
+}
+.scc-actions {
+  margin: 1rem 0 0;
+  padding-left: 1.35rem;
+}
+.scc-actions li {
+  margin-bottom: 0.8rem;
+  padding-left: 0.35rem;
+}
+.scc-email,
+.scc-cta {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.72fr);
+  gap: 2rem;
+  align-items: center;
+}
+.scc-email form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.65rem;
+  align-items: center;
+  position: relative;
+}
+.scc-consent {
+  grid-column: 1 / -1;
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+.scc-consent a {
+  color: inherit;
+  text-decoration: underline;
+}
+.scc-honeypot {
+  position: absolute !important;
+  left: -10000px !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+}
+.scc-cta .btn {
+  justify-self: end;
+}
+.scc-message {
+  margin: 1rem 0 0;
+  font-size: 0.9rem;
+}
+.scc-email > .scc-message {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+.scc-message--error {
+  color: #fca5a5;
+}
+.scc-message--success {
+  color: #86efac;
+}
+.scc-disclaimer {
+  max-width: 780px;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+@media (max-width: 900px) {
+  .scc-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .scc-email,
+  .scc-cta {
+    grid-template-columns: 1fr;
+  }
+  .scc-cta .btn {
+    justify-self: start;
+  }
+}
+@media (max-width: 640px) {
+  .scc-fields,
+  .scc-metrics {
+    grid-template-columns: 1fr;
+  }
+  .scc-email form {
+    grid-template-columns: 1fr;
+  }
+  .scc-consent {
+    grid-column: auto;
+  }
+  .scc-cost-list > div,
+  .scc-formula > div {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  .scc-cost-list dd,
+  .scc-formula dd {
+    text-align: left;
+  }
+}
+@media print {
+  .scc-form,
+  .scc-email,
+  .scc-cta,
+  .scc-result-actions,
+  .scc-proof-row {
+    display: none !important;
+  }
+  .scc-result {
+    margin-top: 0 !important;
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -20,6 +20,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/tools/conflict-check-audit"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/paralegal-capacity-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/intake-leak-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
+    { url: absoluteUrl("/tools/law-firm-stack-cost-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/guides"), lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: absoluteUrl("/about"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/contact"), lastModified: now, changeFrequency: "monthly", priority: 0.7 },

--- a/app/tools/law-firm-stack-cost-calculator/page.tsx
+++ b/app/tools/law-firm-stack-cost-calculator/page.tsx
@@ -1,0 +1,125 @@
+import type { Metadata } from "next";
+import { LawFirmStackCostCalculator } from "@/components/LawFirmStackCostCalculator";
+import { STACK_COST_FAQ } from "@/lib/law-firm-stack-cost";
+import { absoluteUrl, faqPageJsonLd } from "@/lib/seo";
+
+const TITLE = "Law firm tech stack cost calculator";
+const DESCRIPTION =
+  "Calculate the true annual cost of your law firm's software stack, including licenses, setup, maintenance, attorney time, and disruptions. Free, instant, and no signup required.";
+const URL = absoluteUrl("/tools/law-firm-stack-cost-calculator");
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: URL },
+  openGraph: {
+    title: `${TITLE} | Counterbench.AI`,
+    description: DESCRIPTION,
+    url: URL,
+    type: "website",
+  },
+};
+
+function softwareApplicationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: TITLE,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    description: DESCRIPTION,
+    url: URL,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    isAccessibleForFree: true,
+  };
+}
+
+export default function LawFirmStackCostCalculatorPage() {
+  return (
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd()) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageJsonLd(STACK_COST_FAQ)) }}
+      />
+
+      <section className="section" style={{ paddingTop: 108, paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="label">Free tool</div>
+          <h1 className="max-w-900">What is your law firm tech stack actually costing?</h1>
+          <p className="max-w-820 mt-4" style={{ fontSize: "1.125rem" }}>
+            Add the licenses, setup time, maintenance, and attorney hours. See the true annual cost of running the stack
+            yourself, plus the clearest next move: keep it, simplify it, replace the weak link, or hand off the operation.
+          </p>
+
+          <div className="scc-proof-row mt-5" aria-label="Tool details">
+            <span>Free</span>
+            <span>About two minutes</span>
+            <span>No client data</span>
+            <span>Result shown before email</span>
+          </div>
+
+          <LawFirmStackCostCalculator />
+        </div>
+      </section>
+
+      <section className="section section--alt section--border-t" style={{ paddingTop: "4rem", paddingBottom: "4rem" }}>
+        <div className="container">
+          <div className="grid grid--2 grid--gap-3">
+            <div>
+              <div className="label">How the calculation works</div>
+              <h2 className="max-w-700">The invoice is only the visible cost</h2>
+              <p className="max-w-700 mt-4">
+                Software spend is annualized. The calculator then values build time, routine maintenance, and time lost
+                to disruptions using the hourly value you enter. Setup appears in year one. Maintenance, licenses, and
+                disruptions repeat each year.
+              </p>
+              <p className="max-w-700">
+                The recommendation follows the dominant cost pattern. It doesn&apos;t assume that buying, building, or
+                outsourcing is always the right answer.
+              </p>
+            </div>
+            <div className="card card--no-hover">
+              <div className="label">Formula</div>
+              <dl className="scc-formula mt-4">
+                <div>
+                  <dt>Annual licenses</dt>
+                  <dd>Monthly software spend × 12</dd>
+                </div>
+                <div>
+                  <dt>Setup labor</dt>
+                  <dd>Build and migration hours × hourly value</dd>
+                </div>
+                <div>
+                  <dt>Maintenance labor</dt>
+                  <dd>Monthly maintenance hours × 12 × hourly value</dd>
+                </div>
+                <div>
+                  <dt>Disruption cost</dt>
+                  <dd>Quarterly disruptions × 4 × team hours lost × hourly value</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+
+          <h2 className="mt-6">Questions</h2>
+          <dl className="max-w-820 mt-4">
+            {STACK_COST_FAQ.map((faq) => (
+              <div key={faq.q} style={{ marginBottom: "1.25rem" }}>
+                <dt>
+                  <strong>{faq.q}</strong>
+                </dt>
+                <dd className="text-muted" style={{ margin: "0.35rem 0 0" }}>
+                  {faq.a}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/LawFirmStackCostCalculator.tsx
+++ b/components/LawFirmStackCostCalculator.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  calculateStackCost,
+  type StackCostInputs,
+  type StackOwnerRole,
+} from "@/lib/law-firm-stack-cost";
+
+const TOOL_SLUG = "law-firm-stack-cost-calculator";
+
+type FormValues = Record<
+  | "monthlySoftwareCost"
+  | "setupHours"
+  | "monthlyMaintenanceHours"
+  | "ownerHourlyValue"
+  | "disruptionsPerQuarter"
+  | "hoursLostPerDisruption",
+  string
+> & { ownerRole: StackOwnerRole | "" };
+
+const INITIAL_VALUES: FormValues = {
+  monthlySoftwareCost: "",
+  setupHours: "0",
+  monthlyMaintenanceHours: "",
+  ownerRole: "",
+  ownerHourlyValue: "",
+  disruptionsPerQuarter: "0",
+  hoursLostPerDisruption: "0",
+};
+
+const OWNER_LABELS: Record<StackOwnerRole, string> = {
+  "managing-attorney": "Managing attorney or partner",
+  attorney: "Attorney",
+  paralegal: "Paralegal or legal assistant",
+  operations: "Operations or IT staff",
+  external: "External consultant",
+};
+
+const DRIVER_LABELS = {
+  software: "Software licenses",
+  setup: "Build and migration time",
+  maintenance: "Ongoing maintenance",
+  disruption: "Disruptions",
+};
+
+function pushEvent(event: Record<string, unknown>) {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(event);
+}
+
+function parseInput(value: string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : Number.NaN;
+}
+
+function dollars(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function hours(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 }).format(value);
+}
+
+export function LawFirmStackCostCalculator() {
+  const [values, setValues] = useState<FormValues>(INITIAL_VALUES);
+  const [submittedInputs, setSubmittedInputs] = useState<StackCostInputs | null>(null);
+  const [formError, setFormError] = useState("");
+  const [email, setEmail] = useState("");
+  const [company, setCompany] = useState("");
+  const [emailStatus, setEmailStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [emailMessage, setEmailMessage] = useState("");
+
+  useEffect(() => {
+    pushEvent({ event: "tool_view", tool_slug: TOOL_SLUG });
+  }, []);
+
+  const result = useMemo(
+    () => (submittedInputs ? calculateStackCost(submittedInputs) : null),
+    [submittedInputs],
+  );
+
+  function update<K extends keyof FormValues>(key: K, value: FormValues[K]) {
+    setValues((current) => ({ ...current, [key]: value }));
+  }
+
+  function calculate() {
+    const numeric = {
+      monthlySoftwareCost: parseInput(values.monthlySoftwareCost),
+      setupHours: parseInput(values.setupHours),
+      monthlyMaintenanceHours: parseInput(values.monthlyMaintenanceHours),
+      ownerHourlyValue: parseInput(values.ownerHourlyValue),
+      disruptionsPerQuarter: parseInput(values.disruptionsPerQuarter),
+      hoursLostPerDisruption: parseInput(values.hoursLostPerDisruption),
+    };
+
+    if (!values.ownerRole || Object.values(numeric).some((value) => Number.isNaN(value))) {
+      setFormError("The cost couldn't be calculated. Complete every field with a number of zero or more.");
+      return;
+    }
+
+    const inputs: StackCostInputs = { ...numeric, ownerRole: values.ownerRole };
+    const calculated = calculateStackCost(inputs);
+    setFormError("");
+    setSubmittedInputs(inputs);
+    setEmailStatus("idle");
+    setEmailMessage("");
+    pushEvent({
+      event: "stack_cost_calculated",
+      tool_slug: TOOL_SLUG,
+      verdict: calculated.verdict.key,
+      owner_role: inputs.ownerRole,
+      dominant_cost_driver: calculated.dominantCostDriver,
+    });
+    requestAnimationFrame(() => {
+      document.getElementById("stack-cost-result")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+  }
+
+  function reset() {
+    setValues(INITIAL_VALUES);
+    setSubmittedInputs(null);
+    setFormError("");
+    setEmail("");
+    setCompany("");
+    setEmailStatus("idle");
+    setEmailMessage("");
+  }
+
+  async function sendBreakdown() {
+    if (!submittedInputs || !result) return;
+
+    setEmailStatus("sending");
+    setEmailMessage("");
+
+    try {
+      const response = await fetch("/api/stack-cost-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, company, inputs: submittedInputs }),
+      });
+      const body = (await response.json().catch(() => ({}))) as { message?: string };
+
+      if (!response.ok) {
+        setEmailStatus("error");
+        setEmailMessage(body.message || "The breakdown couldn't be sent. Print or save this page instead.");
+        return;
+      }
+
+      setEmailStatus("sent");
+      setEmailMessage("Breakdown sent. Check your inbox.");
+      pushEvent({
+        event: "stack_cost_report_requested",
+        tool_slug: TOOL_SLUG,
+        verdict: result.verdict.key,
+      });
+    } catch {
+      setEmailStatus("error");
+      setEmailMessage("The breakdown couldn't be sent. Check your connection and try again.");
+    }
+  }
+
+  return (
+    <div className="scc">
+      <form
+        className="card scc-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          calculate();
+        }}
+      >
+        <div className="label">Your current stack</div>
+        <h2>Count the cost that doesn't appear on an invoice</h2>
+        <p className="text-muted max-w-700">
+          Use firm-level estimates only. Don&apos;t enter client names, matter details, or confidential information.
+        </p>
+
+        <div className="scc-fields mt-5">
+          <label>
+            <span>Monthly software spend</span>
+            <span className="scc-input-affix">
+              <span aria-hidden="true">$</span>
+              <input
+                name="monthlySoftwareCost"
+                type="number"
+                min="0"
+                step="1"
+                inputMode="decimal"
+                required
+                placeholder="2,400"
+                value={values.monthlySoftwareCost}
+                onChange={(event) => update("monthlySoftwareCost", event.target.value)}
+              />
+            </span>
+            <small>Include practice management, intake, research, automation, and storage</small>
+          </label>
+
+          <label>
+            <span>Build and migration time</span>
+            <span className="scc-input-suffix">
+              <input
+                name="setupHours"
+                type="number"
+                min="0"
+                step="0.5"
+                inputMode="decimal"
+                required
+                value={values.setupHours}
+                onChange={(event) => update("setupHours", event.target.value)}
+              />
+              <span aria-hidden="true">hours</span>
+            </span>
+            <small>Count the time spent setting up or migrating this stack</small>
+          </label>
+
+          <label>
+            <span>Ongoing maintenance</span>
+            <span className="scc-input-suffix">
+              <input
+                name="monthlyMaintenanceHours"
+                type="number"
+                min="0"
+                step="0.5"
+                inputMode="decimal"
+                required
+                placeholder="12"
+                value={values.monthlyMaintenanceHours}
+                onChange={(event) => update("monthlyMaintenanceHours", event.target.value)}
+              />
+              <span aria-hidden="true">hours / month</span>
+            </span>
+            <small>Include updates, fixes, user support, and manual data cleanup</small>
+          </label>
+
+          <label>
+            <span>Who owns the stack?</span>
+            <select
+              name="ownerRole"
+              required
+              value={values.ownerRole}
+              onChange={(event) => update("ownerRole", event.target.value as StackOwnerRole | "")}
+            >
+              <option value="">Select a role</option>
+              {Object.entries(OWNER_LABELS).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+            <small>Choose the person who handles routine maintenance and failures</small>
+          </label>
+
+          <label>
+            <span>Hourly value used for the estimate</span>
+            <span className="scc-input-affix">
+              <span aria-hidden="true">$</span>
+              <input
+                name="ownerHourlyValue"
+                type="number"
+                min="0"
+                step="1"
+                inputMode="decimal"
+                required
+                placeholder="350"
+                value={values.ownerHourlyValue}
+                onChange={(event) => update("ownerHourlyValue", event.target.value)}
+              />
+            </span>
+            <small>Use loaded employment cost, billable value, or a blended team rate</small>
+          </label>
+
+          <label>
+            <span>Disruptions</span>
+            <span className="scc-input-suffix">
+              <input
+                name="disruptionsPerQuarter"
+                type="number"
+                min="0"
+                step="0.5"
+                inputMode="decimal"
+                required
+                value={values.disruptionsPerQuarter}
+                onChange={(event) => update("disruptionsPerQuarter", event.target.value)}
+              />
+              <span aria-hidden="true">per quarter</span>
+            </span>
+            <small>Count failures that interrupt intake, drafting, communication, or case work</small>
+          </label>
+
+          <label>
+            <span>Team time lost per disruption</span>
+            <span className="scc-input-suffix">
+              <input
+                name="hoursLostPerDisruption"
+                type="number"
+                min="0"
+                step="0.5"
+                inputMode="decimal"
+                required
+                value={values.hoursLostPerDisruption}
+                onChange={(event) => update("hoursLostPerDisruption", event.target.value)}
+              />
+              <span aria-hidden="true">hours</span>
+            </span>
+            <small>Combine the time lost by everyone affected</small>
+          </label>
+        </div>
+
+        <div className="scc-form-actions mt-5">
+          <button type="submit" className="btn btn--primary">
+            Calculate ownership cost
+          </button>
+          <span className="text-muted">About two minutes</span>
+        </div>
+        {formError ? (
+          <p className="scc-message scc-message--error" role="alert">
+            {formError}
+          </p>
+        ) : null}
+      </form>
+
+      {result && submittedInputs ? (
+        <section id="stack-cost-result" className="scc-result" aria-live="polite">
+          <div className="card scc-result-hero">
+            <div className="label">Your result</div>
+            <p className="scc-total-label">Your stack costs about</p>
+            <p className="scc-total">{dollars(result.firstYearCost)}</p>
+            <p className="scc-total-label">in the first year</p>
+            <div className="scc-verdict mt-4">
+              <span className={`scc-verdict-dot scc-verdict-dot--${result.verdict.key}`} aria-hidden="true" />
+              <div>
+                <h2>{result.verdict.title}</h2>
+                <p>{result.verdict.summary}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="scc-metrics mt-4">
+            <div className="card">
+              <div className="label">Hidden labor</div>
+              <strong>{dollars(result.hiddenLaborCost)}</strong>
+              <p>{Math.round(result.hiddenLaborShare * 100)}% of first-year cost</p>
+            </div>
+            <div className="card">
+              <div className="label">Operator time</div>
+              <strong>{hours(result.firstYearOperatorHours)} hours</strong>
+              <p>{hours(result.recurringOperatorHours)} recurring hours each year</p>
+            </div>
+            <div className="card">
+              <div className="label">Three-year cost</div>
+              <strong>{dollars(result.threeYearCost)}</strong>
+              <p>{dollars(result.recurringAnnualCost)} recurring each year</p>
+            </div>
+            <div className="card">
+              <div className="label">Largest cost driver</div>
+              <strong>{DRIVER_LABELS[result.dominantCostDriver]}</strong>
+              <p>{dollars(result.annualDowntimeCost)} lost to disruption each year</p>
+            </div>
+          </div>
+
+          <div className="grid grid--2 grid--gap-2 mt-4 scc-breakdown">
+            <div className="card">
+              <div className="label">First-year breakdown</div>
+              <dl className="scc-cost-list">
+                <div>
+                  <dt>Software licenses</dt>
+                  <dd>{dollars(result.annualLicenseCost)}</dd>
+                </div>
+                <div>
+                  <dt>Build and migration time</dt>
+                  <dd>{dollars(result.setupLaborCost)}</dd>
+                </div>
+                <div>
+                  <dt>Ongoing maintenance</dt>
+                  <dd>{dollars(result.annualMaintenanceCost)}</dd>
+                </div>
+                <div>
+                  <dt>Disruptions</dt>
+                  <dd>{dollars(result.annualDowntimeCost)}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="card">
+              <div className="label">Next three actions</div>
+              <ol className="scc-actions">
+                {result.verdict.actions.map((action) => (
+                  <li key={action}>{action}</li>
+                ))}
+              </ol>
+            </div>
+          </div>
+
+          <div className="card scc-email mt-4">
+            <div>
+              <div className="label">Keep the breakdown</div>
+              <h3>Get these numbers by email</h3>
+              <p className="text-muted">
+                We&apos;ll send the result and next three actions. No client or matter data is included.
+              </p>
+            </div>
+            {emailStatus !== "sent" ? (
+              <form
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void sendBreakdown();
+                }}
+              >
+                <label className="sr-only" htmlFor="stack-report-email">
+                  Work email
+                </label>
+                <input
+                  id="stack-report-email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="email"
+                  required
+                  placeholder="you@firm.com"
+                  value={email}
+                  onChange={(event) => setEmail(event.target.value)}
+                  aria-invalid={emailStatus === "error" ? true : undefined}
+                />
+                <input
+                  className="scc-honeypot"
+                  tabIndex={-1}
+                  autoComplete="off"
+                  aria-hidden="true"
+                  name="company"
+                  value={company}
+                  onChange={(event) => setCompany(event.target.value)}
+                />
+                <button type="submit" className="btn btn--primary btn--sm" disabled={emailStatus === "sending"}>
+                  {emailStatus === "sending" ? "Sending…" : "Email the breakdown"}
+                </button>
+                <p className="text-muted scc-consent">
+                  Counterbench may follow up about this result. See our <Link href="/privacy">privacy policy</Link>.
+                </p>
+              </form>
+            ) : null}
+            {emailMessage ? (
+              <p
+                className={`scc-message ${emailStatus === "error" ? "scc-message--error" : "scc-message--success"}`}
+                role={emailStatus === "error" ? "alert" : "status"}
+              >
+                {emailMessage}
+              </p>
+            ) : null}
+          </div>
+
+          <div className="card scc-cta mt-4">
+            <div>
+              <div className="label">Need a second opinion?</div>
+              <h3>See what to keep, replace, or hand off</h3>
+              <p className="text-muted">
+                Counterbench Advisory reviews the stack and the workflows around it. No software commissions and no
+                preferred vendors.
+              </p>
+            </div>
+            <Link
+              href="/advisory?from=stack-cost-calculator"
+              className="btn btn--primary btn--arrow"
+              onClick={() =>
+                pushEvent({
+                  event: "tool_click_cta",
+                  tool_slug: TOOL_SLUG,
+                  destination: "/advisory",
+                  verdict: result.verdict.key,
+                })
+              }
+            >
+              Review my stack
+            </Link>
+          </div>
+
+          <div className="scc-result-actions mt-5">
+            <button type="button" className="btn btn--secondary btn--sm" onClick={() => window.print()}>
+              Print or save as PDF
+            </button>
+            <button type="button" className="btn btn--secondary btn--sm" onClick={reset}>
+              Start over
+            </button>
+          </div>
+
+          <p className="text-muted scc-disclaimer mt-4">
+            This estimate uses the hourly value you entered. It isn&apos;t an accounting valuation or a recommendation to
+            buy or replace any specific product.
+          </p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/law-firm-stack-cost.ts
+++ b/lib/law-firm-stack-cost.ts
@@ -1,0 +1,214 @@
+export type StackOwnerRole =
+  | "managing-attorney"
+  | "attorney"
+  | "paralegal"
+  | "operations"
+  | "external";
+
+export type StackVerdictKey = "keep" | "simplify" | "hand-off" | "replace-weak-link";
+
+export interface StackCostInputs {
+  monthlySoftwareCost: number;
+  setupHours: number;
+  monthlyMaintenanceHours: number;
+  ownerRole: StackOwnerRole;
+  ownerHourlyValue: number;
+  disruptionsPerQuarter: number;
+  hoursLostPerDisruption: number;
+}
+
+export interface StackVerdict {
+  key: StackVerdictKey;
+  title: string;
+  summary: string;
+  actions: string[];
+}
+
+export interface StackCostResult {
+  annualLicenseCost: number;
+  setupLaborCost: number;
+  annualMaintenanceHours: number;
+  annualMaintenanceCost: number;
+  annualDowntimeHours: number;
+  annualDowntimeCost: number;
+  firstYearOperatorHours: number;
+  recurringOperatorHours: number;
+  hiddenLaborCost: number;
+  firstYearCost: number;
+  recurringAnnualCost: number;
+  threeYearCost: number;
+  hiddenLaborShare: number;
+  recurringLaborShare: number;
+  dominantCostDriver: "software" | "setup" | "maintenance" | "disruption";
+  verdict: StackVerdict;
+}
+
+const ATTORNEY_ROLES: StackOwnerRole[] = ["managing-attorney", "attorney"];
+
+function finiteNonNegative(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function dominantDriver(values: Record<StackCostResult["dominantCostDriver"], number>) {
+  return (Object.entries(values) as Array<[StackCostResult["dominantCostDriver"], number]>).reduce(
+    (largest, current) => (current[1] > largest[1] ? current : largest),
+  )[0];
+}
+
+function verdictFor(params: {
+  inputs: StackCostInputs;
+  annualLicenseCost: number;
+  annualDowntimeCost: number;
+  annualDowntimeHours: number;
+  recurringOperatorHours: number;
+  recurringLaborShare: number;
+}): StackVerdict {
+  const {
+    inputs,
+    annualLicenseCost,
+    annualDowntimeCost,
+    annualDowntimeHours,
+    recurringOperatorHours,
+    recurringLaborShare,
+  } = params;
+
+  const disruptionsAreMaterial =
+    inputs.disruptionsPerQuarter >= 3 &&
+    (annualDowntimeHours >= 48 || annualDowntimeCost >= annualLicenseCost * 0.25);
+
+  if (disruptionsAreMaterial) {
+    return {
+      key: "replace-weak-link",
+      title: "Replace the weak link",
+      summary:
+        "Disruptions now cost enough time to justify replacing the system or connection that causes them. Identify that failure point before replacing the whole stack.",
+      actions: [
+        "Name the system or connection behind the last three disruptions",
+        "Set a maximum acceptable outage cost before the next renewal",
+        "Compare one replacement against the cost of another year of disruption",
+      ],
+    };
+  }
+
+  const attorneyOwnsStack = ATTORNEY_ROLES.includes(inputs.ownerRole);
+  if (attorneyOwnsStack && recurringOperatorHours >= 60) {
+    return {
+      key: "hand-off",
+      title: "Hand off the operation",
+      summary:
+        "The stack may be worth keeping, but an attorney is spending too much time running it. Move routine ownership before changing the software.",
+      actions: [
+        "Assign one operational owner and one backup",
+        "Document maintenance, access, and failure-recovery steps",
+        "Keep attorney involvement for approvals and exceptions",
+      ],
+    };
+  }
+
+  if (recurringOperatorHours >= 120 || recurringLaborShare >= 0.5) {
+    return {
+      key: "simplify",
+      title: "Simplify the stack",
+      summary:
+        "Labor now drives at least as much cost as the software. Remove duplicate tools and the manual connections that require the most upkeep.",
+      actions: [
+        "Rank every tool by use, cost, and maintenance time",
+        "Remove the lowest-value duplicate before adding another tool",
+        "Replace the most manual connection with a supported integration",
+      ],
+    };
+  }
+
+  return {
+    key: "keep",
+    title: "Keep the stack",
+    summary:
+      "The visible software cost still accounts for most of the total, and your firm has kept the recurring operator load low. Protect that advantage with clear ownership.",
+    actions: [
+      "Keep a current list of tools, owners, and renewal dates",
+      "Review maintenance time once per quarter",
+      "Set a disruption threshold that triggers a replacement review",
+    ],
+  };
+}
+
+export function calculateStackCost(raw: StackCostInputs): StackCostResult {
+  const inputs: StackCostInputs = {
+    monthlySoftwareCost: finiteNonNegative(raw.monthlySoftwareCost),
+    setupHours: finiteNonNegative(raw.setupHours),
+    monthlyMaintenanceHours: finiteNonNegative(raw.monthlyMaintenanceHours),
+    ownerRole: raw.ownerRole,
+    ownerHourlyValue: finiteNonNegative(raw.ownerHourlyValue),
+    disruptionsPerQuarter: finiteNonNegative(raw.disruptionsPerQuarter),
+    hoursLostPerDisruption: finiteNonNegative(raw.hoursLostPerDisruption),
+  };
+
+  const annualLicenseCost = inputs.monthlySoftwareCost * 12;
+  const setupLaborCost = inputs.setupHours * inputs.ownerHourlyValue;
+  const annualMaintenanceHours = inputs.monthlyMaintenanceHours * 12;
+  const annualMaintenanceCost = annualMaintenanceHours * inputs.ownerHourlyValue;
+  const annualDowntimeHours = inputs.disruptionsPerQuarter * 4 * inputs.hoursLostPerDisruption;
+  const annualDowntimeCost = annualDowntimeHours * inputs.ownerHourlyValue;
+  const recurringOperatorHours = annualMaintenanceHours + annualDowntimeHours;
+  const firstYearOperatorHours = inputs.setupHours + recurringOperatorHours;
+  const hiddenLaborCost = setupLaborCost + annualMaintenanceCost + annualDowntimeCost;
+  const recurringAnnualCost = annualLicenseCost + annualMaintenanceCost + annualDowntimeCost;
+  const firstYearCost = recurringAnnualCost + setupLaborCost;
+  const threeYearCost = firstYearCost + recurringAnnualCost * 2;
+  const hiddenLaborShare = firstYearCost > 0 ? hiddenLaborCost / firstYearCost : 0;
+  const recurringLaborCost = annualMaintenanceCost + annualDowntimeCost;
+  const recurringLaborShare = recurringAnnualCost > 0 ? recurringLaborCost / recurringAnnualCost : 0;
+  const dominantCostDriver = dominantDriver({
+    software: annualLicenseCost,
+    setup: setupLaborCost,
+    maintenance: annualMaintenanceCost,
+    disruption: annualDowntimeCost,
+  });
+
+  const verdict = verdictFor({
+    inputs,
+    annualLicenseCost,
+    annualDowntimeCost,
+    annualDowntimeHours,
+    recurringOperatorHours,
+    recurringLaborShare,
+  });
+
+  return {
+    annualLicenseCost,
+    setupLaborCost,
+    annualMaintenanceHours,
+    annualMaintenanceCost,
+    annualDowntimeHours,
+    annualDowntimeCost,
+    firstYearOperatorHours,
+    recurringOperatorHours,
+    hiddenLaborCost,
+    firstYearCost,
+    recurringAnnualCost,
+    threeYearCost,
+    hiddenLaborShare,
+    recurringLaborShare,
+    dominantCostDriver,
+    verdict,
+  };
+}
+
+export const STACK_COST_FAQ = [
+  {
+    q: "What counts as law firm technology stack cost?",
+    a: "The calculator includes software licenses, build and migration time, ongoing maintenance, and time lost when systems or connections fail.",
+  },
+  {
+    q: "How should I value attorney or staff time?",
+    a: "Use a loaded hourly employment cost for a conservative estimate, or the value of time redirected from billable work to measure opportunity cost.",
+  },
+  {
+    q: "Does a high result mean the firm should replace its software?",
+    a: "No. A high result may mean the stack needs simpler connections or a different operational owner. The calculator separates software, maintenance, setup, and disruption costs so the firm can address the real driver.",
+  },
+  {
+    q: "Does this calculator require client or matter data?",
+    a: "No. It uses only firm-level cost and time estimates. Do not enter client names, matter details, or confidential information.",
+  },
+];

--- a/tests/e2e/stack-cost-calculator.spec.ts
+++ b/tests/e2e/stack-cost-calculator.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+async function completeCalculator(page: import("@playwright/test").Page) {
+  await page.getByLabel("Monthly software spend").fill("2000");
+  await page.getByLabel("Build and migration time").fill("0");
+  await page.getByLabel("Ongoing maintenance").fill("6");
+  await page.getByLabel("Who owns the stack?").selectOption("managing-attorney");
+  await page.getByLabel("Hourly value used for the estimate").fill("350");
+  await page.getByLabel("Disruptions").fill("0");
+  await page.getByLabel("Team time lost per disruption").fill("0");
+  await page.getByRole("button", { name: "Calculate ownership cost" }).click();
+}
+
+test.describe("Law firm tech stack cost calculator", () => {
+  test("calculates an ungated result and gives a next action", async ({ page }) => {
+    await page.goto("/tools/law-firm-stack-cost-calculator");
+
+    await expect(
+      page.getByRole("heading", { name: "What is your law firm tech stack actually costing?" }),
+    ).toBeVisible();
+
+    await completeCalculator(page);
+
+    const result = page.locator("#stack-cost-result");
+    await expect(result).toBeVisible();
+    await expect(result.getByText("$49,200", { exact: true })).toBeVisible();
+    await expect(result.getByRole("heading", { name: "Hand off the operation" })).toBeVisible();
+    await expect(result.getByRole("link", { name: "Review my stack" })).toHaveAttribute(
+      "href",
+      "/advisory?from=stack-cost-calculator",
+    );
+    await expect(result.getByRole("button", { name: "Email the breakdown" })).toBeVisible();
+  });
+
+  test("fits a mobile viewport without horizontal scrolling", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/tools/law-firm-stack-cost-calculator");
+    await completeCalculator(page);
+
+    const dimensions = await page.evaluate(() => ({
+      viewport: document.documentElement.clientWidth,
+      content: document.documentElement.scrollWidth,
+    }));
+    expect(dimensions.content).toBeLessThanOrEqual(dimensions.viewport + 1);
+    await expect(page.locator("#stack-cost-result")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add an ungated law firm technology-stack ownership cost calculator
- email detailed reports through Resend and forward captured leads through the existing n8n webhook
- add the tool to Resources and the sitemap with responsive, accessible styling

## Verification
- npx vitest run __tests__/law-firm-stack-cost.test.ts
- npm run typecheck
- npm run build
- npx playwright test tests/e2e/stack-cost-calculator.spec.ts