### PR TITLE
feat(tools): add Google LSA intake leak calculator

### DIFF
--- a/__tests__/intake-leak-calculator.test.ts
+++ b/__tests__/intake-leak-calculator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { calculateIntakeLeak, INTAKE_LEAK_DEFAULTS } from "@/lib/intake-leak-calculator";
+
+describe("calculateIntakeLeak", () => {
+  it("calculates the default monthly leak", () => {
+    const result = calculateIntakeLeak(INTAKE_LEAK_DEFAULTS);
+
+    expect(result.seriousCalls).toBeCloseTo(14.4);
+    expect(result.nonSeriousCalls).toBeCloseTo(105.6);
+    expect(result.nonSeriousAdSpend).toBeCloseTo(3168);
+    expect(result.staffHours).toBeCloseTo(15.84);
+    expect(result.staffCost).toBeCloseTo(506.88);
+    expect(result.monthlyLeak).toBeCloseTo(3674.88);
+    expect(result.annualLeak).toBeCloseTo(44098.56);
+    expect(result.costPerSeriousInquiry).toBeCloseTo(250);
+  });
+
+  it("returns null ratios when the serious-inquiry rate is zero", () => {
+    const result = calculateIntakeLeak({ ...INTAKE_LEAK_DEFAULTS, seriousRate: 0 });
+
+    expect(result.seriousCalls).toBe(0);
+    expect(result.callsPerSeriousInquiry).toBeNull();
+    expect(result.costPerSeriousInquiry).toBeNull();
+  });
+
+  it("clamps percentages and negative inputs", () => {
+    const result = calculateIntakeLeak({
+      callVolume: -10,
+      costPerCall: -5,
+      seriousRate: 140,
+      averageMinutes: -1,
+      hourlyCost: -20,
+    });
+
+    expect(result.callVolume).toBe(0);
+    expect(result.costPerCall).toBe(0);
+    expect(result.seriousRate).toBe(100);
+    expect(result.averageMinutes).toBe(0);
+    expect(result.hourlyCost).toBe(0);
+    expect(result.monthlyLeak).toBe(0);
+  });
+
+  it("accepts form values as strings", () => {
+    const result = calculateIntakeLeak({
+      callVolume: "50",
+      costPerCall: "30",
+      seriousRate: "2",
+      averageMinutes: "10",
+      hourlyCost: "30",
+    });
+
+    expect(result.nonSeriousCalls).toBe(49);
+    expect(result.staffHours).toBeCloseTo(8.1667, 3);
+    expect(result.monthlyLeak).toBeCloseTo(1715);
+  });
+});

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,6 +18,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: absoluteUrl("/tools/source-finder"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
     { url: absoluteUrl("/tools/contract-qa-planner"), lastModified: now, changeFrequency: "weekly", priority: 0.74 },
     { url: absoluteUrl("/tools/conflict-check-audit"), lastModified: now, changeFrequency: "weekly", priority: 0.75 },
+    { url: absoluteUrl("/tools/intake-leak-calculator"), lastModified: now, changeFrequency: "weekly", priority: 0.76 },
     { url: absoluteUrl("/guides"), lastModified: now, changeFrequency: "weekly", priority: 0.8 },
     { url: absoluteUrl("/about"), lastModified: now, changeFrequency: "monthly", priority: 0.6 },
     { url: absoluteUrl("/contact"), lastModified: now, changeFrequency: "monthly", priority: 0.7 },

--- a/app/tools/intake-leak-calculator/intake-leak-calculator.module.css
+++ b/app/tools/intake-leak-calculator/intake-leak-calculator.module.css
@@ -1,0 +1,375 @@
+.page {
+  --intake-ink: #12243d;
+  --intake-ink-dark: #0b182a;
+  --intake-paper: #f4f1e9;
+  --intake-paper-deep: #e8e3d7;
+  --intake-white: #fbfaf5;
+  --intake-signal: #c9ec58;
+  --intake-signal-dark: #91b11c;
+  --intake-muted: #687180;
+  --intake-line: rgba(18, 36, 61, 0.2);
+  color: var(--intake-ink);
+  background:
+    linear-gradient(rgba(18, 36, 61, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(18, 36, 61, 0.035) 1px, transparent 1px),
+    var(--intake-paper);
+  background-size: 28px 28px;
+  overflow: hidden;
+}
+
+.hero {
+  min-height: 610px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: clamp(44px, 7vw, 96px) clamp(20px, 6vw, 92px) 48px;
+  color: var(--intake-white);
+  background:
+    radial-gradient(circle at 84% 10%, rgba(201, 236, 88, 0.16), transparent 23rem),
+    linear-gradient(118deg, var(--intake-ink-dark) 0%, var(--intake-ink) 70%, #203855 100%);
+  position: relative;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.14;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='2' stitchTiles='stitchTiles'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.22'/%3E%3C/svg%3E");
+}
+
+.hero > * { position: relative; z-index: 1; }
+
+.heroKicker {
+  display: flex;
+  justify-content: space-between;
+  color: #c8d0dc;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.heroKicker span:first-child::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  display: inline-block;
+  margin-right: 10px;
+  background: var(--intake-signal);
+  border-radius: 50%;
+}
+
+.hero h1 {
+  margin: 58px 0 56px;
+  max-width: 1120px;
+  color: var(--intake-white);
+  font-size: clamp(4rem, 8.5vw, 8.8rem);
+  font-weight: 500;
+  line-height: 0.84;
+  letter-spacing: -0.067em;
+}
+
+.hero h1 em { color: var(--intake-signal); font-style: italic; }
+
+.heroBottom {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 40px;
+}
+
+.heroBottom > p {
+  max-width: 610px;
+  margin: 0;
+  color: #d4dae3;
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  line-height: 1.5;
+}
+
+.caseNote {
+  width: 210px;
+  padding-top: 13px;
+  border-top: 1px solid rgba(255, 255, 255, 0.32);
+}
+
+.caseNote span,
+.caseNote strong { display: block; }
+.caseNote span { color: #9eacbe; font-size: 0.66rem; letter-spacing: 0.1em; text-transform: uppercase; }
+.caseNote strong { margin-top: 7px; font-size: 0.86rem; letter-spacing: 0.08em; }
+
+.calculatorShell {
+  width: min(1240px, calc(100% - 40px));
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(390px, 0.85fr);
+  margin: 0 auto;
+  border: 1px solid var(--intake-line);
+  box-shadow: 0 26px 70px rgba(18, 36, 61, 0.1);
+}
+
+.inputsPanel {
+  padding: clamp(28px, 4vw, 58px);
+  background: var(--intake-white);
+}
+
+.panelHeading,
+.prescriptionHeading { display: flex; gap: 22px; }
+
+.stepNumber {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  color: var(--intake-ink);
+  background: var(--intake-signal);
+  border-radius: 50%;
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
+.overline {
+  margin: 0 0 8px;
+  color: var(--intake-muted);
+  font-size: 0.64rem;
+  font-weight: 700;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.panelHeading h2,
+.prescriptionHeading h2,
+.faqSection h2 {
+  margin: 0;
+  color: var(--intake-ink);
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  font-weight: 600;
+  line-height: 0.98;
+  letter-spacing: -0.045em;
+}
+
+.fieldList { margin-top: 44px; border-top: 1px solid var(--intake-line); }
+
+.fieldRow {
+  display: grid;
+  grid-template-columns: minmax(210px, 1fr) minmax(220px, 0.85fr);
+  align-items: center;
+  gap: 26px;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--intake-line);
+}
+
+.fieldCopy label { color: var(--intake-ink); font-weight: 700; letter-spacing: -0.02em; }
+.fieldCopy p { margin: 5px 0 0; color: var(--intake-muted); font-size: 0.76rem; line-height: 1.45; }
+
+.controlPair {
+  display: grid;
+  grid-template-columns: minmax(100px, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+}
+
+.range {
+  --range-progress: 0%;
+  width: 100%;
+  height: 3px;
+  appearance: none;
+  background: linear-gradient(90deg, var(--intake-ink) var(--range-progress), #d6d7d2 var(--range-progress));
+  border: 0;
+  border-radius: 0;
+}
+
+.range::-webkit-slider-thumb {
+  width: 17px;
+  height: 17px;
+  appearance: none;
+  background: var(--intake-signal);
+  border: 4px solid var(--intake-ink);
+  border-radius: 50%;
+  cursor: grab;
+}
+
+.range::-moz-range-thumb {
+  width: 11px;
+  height: 11px;
+  background: var(--intake-signal);
+  border: 4px solid var(--intake-ink);
+  border-radius: 50%;
+  cursor: grab;
+}
+
+.numberWrap {
+  min-width: 92px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 4px;
+  padding: 9px 10px;
+  background: var(--intake-paper);
+  border: 1px solid transparent;
+}
+
+.numberWrap:focus-within { border-color: var(--intake-ink); outline: 2px solid rgba(201, 236, 88, 0.65); }
+
+.numberWrap input {
+  width: 58px;
+  color: var(--intake-ink);
+  background: transparent;
+  border: 0;
+  outline: 0;
+  text-align: right;
+  font-weight: 700;
+  appearance: textfield;
+}
+
+.numberWrap input::-webkit-inner-spin-button { appearance: none; }
+.numberWrap span { color: var(--intake-muted); font-size: 0.68rem; font-weight: 600; }
+.featuredField { background: linear-gradient(90deg, rgba(201, 236, 88, 0.13), transparent); }
+
+.details { border-bottom: 1px solid var(--intake-line); }
+.details summary {
+  display: flex;
+  justify-content: space-between;
+  padding: 22px 0;
+  color: var(--intake-ink);
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.details summary::-webkit-details-marker { display: none; }
+.details summary span { font-size: 1.2rem; line-height: 0.7; }
+.detailsBody { padding-left: 20px; border-left: 2px solid var(--intake-signal); }
+.detailsBody .fieldRow:last-child { border-bottom: 0; }
+
+.resultsPanel {
+  min-width: 0;
+  padding: clamp(28px, 4vw, 54px);
+  color: var(--intake-white);
+  background:
+    radial-gradient(circle at 85% 0%, rgba(201, 236, 88, 0.13), transparent 17rem),
+    var(--intake-ink);
+}
+
+.resultHeading { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+.resultsPanel .overline { color: #aab7c7; }
+.livePill { display: inline-flex; align-items: center; gap: 7px; color: #c9d4e1; font-size: 0.62rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.livePill i { width: 7px; height: 7px; background: var(--intake-signal); border-radius: 50%; box-shadow: 0 0 0 5px rgba(201, 236, 88, 0.12); }
+
+.primaryResult {
+  display: flex;
+  align-items: baseline;
+  margin: 58px 0 10px;
+  font-family: var(--serif);
+  letter-spacing: -0.06em;
+  white-space: nowrap;
+}
+
+.currencyMark { align-self: flex-start; margin-top: 0.65rem; color: var(--intake-signal); font-size: clamp(1.8rem, 4vw, 3rem); }
+.primaryResult strong { font-size: clamp(4.4rem, 8vw, 7.5rem); line-height: 0.75; font-weight: 500; }
+.cadence { margin-left: 8px; color: #aab7c7; font: 500 0.72rem var(--sans); letter-spacing: 0.02em; }
+.resultDefinition { max-width: 480px; margin: 22px 0 44px; color: #c8d1dc; font-size: 0.85rem; line-height: 1.55; }
+
+.resultGrid { display: grid; grid-template-columns: 1fr 1fr; border-top: 1px solid rgba(255, 255, 255, 0.17); }
+.metric { min-height: 112px; padding: 20px 18px 20px 0; border-bottom: 1px solid rgba(255, 255, 255, 0.17); }
+.metric:nth-child(odd) { border-right: 1px solid rgba(255, 255, 255, 0.17); }
+.metric:nth-child(even) { padding-left: 18px; }
+.metric span { display: block; min-height: 32px; color: #9eacbe; font-size: 0.65rem; line-height: 1.35; text-transform: uppercase; letter-spacing: 0.06em; }
+.metric strong { display: block; margin-top: 10px; font: 500 1.75rem var(--serif); letter-spacing: -0.035em; }
+.annualLine { display: flex; justify-content: space-between; gap: 20px; padding: 25px 0 19px; border-bottom: 1px solid rgba(255, 255, 255, 0.17); }
+.annualLine span { color: #9eacbe; font-size: 0.66rem; letter-spacing: 0.07em; text-transform: uppercase; }
+.annualLine strong { color: var(--intake-signal); font-size: 1.05rem; }
+.resultNote { margin: 17px 0 0; color: #9eacbe; font-size: 0.7rem; line-height: 1.5; }
+
+.prescription {
+  width: min(1240px, calc(100% - 40px));
+  margin: 110px auto;
+}
+
+.prescriptionHeading { align-items: flex-start; }
+.prescriptionHeading h2 { max-width: 760px; }
+.layers { display: grid; grid-template-columns: 1fr 1fr; margin: 56px 0 0 58px; border-top: 1px solid var(--intake-line); border-bottom: 1px solid var(--intake-line); }
+.layers article { padding: 34px 44px 38px 0; }
+.layers article + article { padding-left: 44px; border-left: 1px solid var(--intake-line); }
+.layers article > span { color: var(--intake-signal-dark); font-size: 0.65rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; }
+.layers h3 { margin: 28px 0 12px; color: var(--intake-ink); font-size: 1.8rem; font-weight: 600; line-height: 1.05; letter-spacing: -0.035em; }
+.layers p { margin: 0; color: var(--intake-muted); font-size: 0.85rem; line-height: 1.65; }
+
+.ctaBand {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 30px;
+  margin: 30px 0 0 58px;
+  padding: 30px 32px;
+  color: var(--intake-white);
+  background: var(--intake-ink);
+}
+.ctaBand span,
+.ctaBand strong { display: block; }
+.ctaBand div > span { margin-bottom: 4px; color: #aab7c7; font-size: 0.72rem; }
+.ctaBand div > strong { font: 500 1.5rem var(--serif); }
+.ctaBand a { flex: 0 0 auto; padding: 15px 18px; color: var(--intake-ink); background: var(--intake-signal); text-decoration: none; font-size: 0.74rem; font-weight: 700; }
+.ctaBand a span { display: inline; }
+.ctaBand a:hover { color: var(--intake-ink-dark); background: #daf785; }
+
+.methodNote {
+  width: min(730px, calc(100% - 40px));
+  margin: 0 auto 100px;
+  padding-left: 20px;
+  border-left: 2px solid var(--intake-signal-dark);
+}
+.methodNote strong { color: var(--intake-ink); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; }
+.methodNote p { margin: 9px 0 0; color: var(--intake-muted); font-size: 0.78rem; line-height: 1.65; }
+
+.faqSection {
+  width: min(980px, calc(100% - 40px));
+  margin: 0 auto;
+  padding: 90px 0 110px;
+  border-top: 1px solid var(--intake-line);
+}
+.faqSection h2 { max-width: 720px; }
+.faqSection dl { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; margin-top: 50px; border-top: 1px solid var(--intake-line); border-bottom: 1px solid var(--intake-line); }
+.faqSection dl > div { padding: 28px 28px 32px 0; }
+.faqSection dl > div + div { padding-left: 28px; border-left: 1px solid var(--intake-line); }
+.faqSection dt { color: var(--intake-ink); font-weight: 700; line-height: 1.35; }
+.faqSection dd { margin: 12px 0 0; color: var(--intake-muted); font-size: 0.8rem; line-height: 1.65; }
+
+@media (max-width: 900px) {
+  .calculatorShell { grid-template-columns: 1fr; }
+  .hero { min-height: 560px; }
+  .faqSection dl { grid-template-columns: 1fr; }
+  .faqSection dl > div + div { padding-left: 0; border-left: 0; border-top: 1px solid var(--intake-line); }
+}
+
+@media (max-width: 640px) {
+  .hero { min-height: 540px; padding-bottom: 34px; }
+  .hero h1 { font-size: clamp(3.5rem, 17vw, 5rem); }
+  .heroBottom { display: block; }
+  .caseNote { display: none; }
+  .calculatorShell,
+  .prescription { width: 100%; border-left: 0; border-right: 0; }
+  .fieldRow { grid-template-columns: 1fr; gap: 18px; }
+  .controlPair { grid-template-columns: 1fr auto; }
+  .primaryResult { margin-top: 46px; }
+  .primaryResult strong { font-size: clamp(4.2rem, 23vw, 6.4rem); }
+  .resultGrid { grid-template-columns: 1fr; }
+  .metric,
+  .metric:nth-child(even) { padding: 18px 0; border-right: 0; }
+  .metric span { min-height: auto; }
+  .layers { grid-template-columns: 1fr; margin-left: 0; }
+  .layers article,
+  .layers article + article { padding: 30px 0; border-left: 0; }
+  .layers article + article { border-top: 1px solid var(--intake-line); }
+  .ctaBand { display: block; margin-left: 0; }
+  .ctaBand a { display: block; margin-top: 24px; text-align: center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page *,
+  .page *::before,
+  .page *::after { scroll-behavior: auto !important; animation: none !important; transition: none !important; }
+}

--- a/app/tools/intake-leak-calculator/page.tsx
+++ b/app/tools/intake-leak-calculator/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from "next";
+import { IntakeLeakCalculator } from "@/components/IntakeLeakCalculator";
+import { absoluteUrl, faqPageJsonLd } from "@/lib/seo";
+import styles from "./intake-leak-calculator.module.css";
+
+const TITLE = "Google LSA Intake Leak Calculator";
+const DESCRIPTION =
+  "Calculate the Google LSA spend and paralegal hours your law firm loses to calls that never become serious inquiries. Free, instant, and no signup.";
+const URL = absoluteUrl("/tools/intake-leak-calculator");
+
+const FAQ = [
+  {
+    q: "What does the Intake Leak Calculator measure?",
+    a: "It estimates the monthly Google LSA spend attached to non-serious calls, then adds the loaded paralegal cost of handling those calls. It also shows the staff hours absorbed and the annualized total.",
+  },
+  {
+    q: "What counts as a serious inquiry?",
+    a: "Use your firm's own definition: a caller with a matter your firm would genuinely consider working. The calculator does not predict signed clients or case value.",
+  },
+  {
+    q: "Why include both automation and a paralegal team?",
+    a: "Automation can screen obvious mismatches quickly. A trained paralegal is better suited to ambiguous, urgent, or poorly explained inquiries where judgment changes the outcome.",
+  },
+];
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: URL },
+  openGraph: {
+    title: `${TITLE} | Counterbench.AI`,
+    description: DESCRIPTION,
+    url: URL,
+    type: "website",
+  },
+};
+
+function softwareApplicationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: TITLE,
+    applicationCategory: "BusinessApplication",
+    operatingSystem: "Web",
+    description: DESCRIPTION,
+    url: URL,
+    offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+    isAccessibleForFree: true,
+  };
+}
+
+export default function IntakeLeakCalculatorPage() {
+  return (
+    <main className={styles.page}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareApplicationJsonLd()) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageJsonLd(FAQ)) }}
+      />
+
+      <section className={styles.hero}>
+        <div className={styles.heroKicker}>
+          <span>Intake ops</span>
+          <span>Free firm tool</span>
+        </div>
+        <h1>Your phones are busy.<br /><em>Your pipeline might not be.</em></h1>
+        <div className={styles.heroBottom}>
+          <p>Put a dollar and time cost on Google LSA calls that never become serious inquiries.</p>
+          <div className={styles.caseNote} aria-hidden="true">
+            <span>Monthly intake review</span>
+            <strong>LSA / TRIAGE</strong>
+          </div>
+        </div>
+      </section>
+
+      <IntakeLeakCalculator />
+
+      <section className={styles.methodNote}>
+        <strong>What this estimate means</strong>
+        <p>
+          “Non-serious” is defined by the rate you enter. The calculator does not predict signed cases or promise
+          recoverable spend. It shows where your current media budget and staff capacity are going so you can decide
+          what to screen, what to staff, and what to keep human.
+        </p>
+      </section>
+
+      <section className={styles.faqSection} aria-labelledby="intake-faq-heading">
+        <p className={styles.overline}>Method notes</p>
+        <h2 id="intake-faq-heading">Questions firms ask before changing intake</h2>
+        <dl>
+          {FAQ.map((item) => (
+            <div key={item.q}>
+              <dt>{item.q}</dt>
+              <dd>{item.a}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </main>
+  );
+}

--- a/components/IntakeLeakCalculator.tsx
+++ b/components/IntakeLeakCalculator.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+  calculateIntakeLeak,
+  INTAKE_LEAK_DEFAULTS,
+  type IntakeLeakInput,
+} from "@/lib/intake-leak-calculator";
+import styles from "@/app/tools/intake-leak-calculator/intake-leak-calculator.module.css";
+
+const TOOL_SLUG = "intake-leak-calculator";
+const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const oneDecimal = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+type FieldKey = keyof IntakeLeakInput;
+
+function pushEvent(event: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer ?? [];
+  window.dataLayer.push(event);
+}
+
+interface InputRowProps {
+  id: string;
+  field: FieldKey;
+  label: string;
+  description: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  unit?: string;
+  prefix?: string;
+  featured?: boolean;
+  onChange: (field: FieldKey, value: number) => void;
+}
+
+function InputRow({
+  id,
+  field,
+  label,
+  description,
+  value,
+  min,
+  max,
+  step,
+  unit,
+  prefix,
+  featured = false,
+  onChange,
+}: InputRowProps) {
+  const boundedRangeValue = Math.min(max, Math.max(min, value));
+  const progress = ((boundedRangeValue - min) / (max - min)) * 100;
+
+  function update(raw: string) {
+    const numeric = Number(raw);
+    onChange(field, Number.isFinite(numeric) ? numeric : 0);
+  }
+
+  return (
+    <div className={`${styles.fieldRow} ${featured ? styles.featuredField : ""}`}>
+      <div className={styles.fieldCopy}>
+        <label htmlFor={id}>{label}</label>
+        <p>{description}</p>
+      </div>
+      <div className={styles.controlPair}>
+        <input
+          className={styles.range}
+          type="range"
+          id={`${id}-range`}
+          aria-label={`${label} slider`}
+          min={min}
+          max={max}
+          step={step}
+          value={boundedRangeValue}
+          style={{ "--range-progress": `${progress}%` } as React.CSSProperties}
+          onChange={(event) => update(event.target.value)}
+        />
+        <div className={styles.numberWrap}>
+          {prefix ? <span>{prefix}</span> : null}
+          <input
+            type="number"
+            id={id}
+            min={0}
+            max={field === "seriousRate" ? 100 : undefined}
+            step={step}
+            value={value}
+            onChange={(event) => update(event.target.value)}
+          />
+          {unit ? <span>{unit}</span> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function IntakeLeakCalculator() {
+  const [inputs, setInputs] = useState<IntakeLeakInput>({ ...INTAKE_LEAK_DEFAULTS });
+  const result = useMemo(() => calculateIntakeLeak(inputs), [inputs]);
+
+  useEffect(() => {
+    pushEvent({ event: "tool_view", tool_slug: TOOL_SLUG });
+  }, []);
+
+  function update(field: FieldKey, value: number) {
+    setInputs((current) => ({ ...current, [field]: value }));
+  }
+
+  function trackCta() {
+    pushEvent({ event: "tool_click_cta", tool_slug: TOOL_SLUG, destination: "/paralegals" });
+  }
+
+  return (
+    <>
+      <section className={styles.calculatorShell} id="calculator" aria-labelledby="calculator-title">
+        <form className={styles.inputsPanel} onSubmit={(event) => event.preventDefault()}>
+          <div className={styles.panelHeading}>
+            <span className={styles.stepNumber}>01</span>
+            <div>
+              <p className={styles.overline}>Enter the monthly numbers</p>
+              <h2 id="calculator-title">What crosses your front desk?</h2>
+            </div>
+          </div>
+
+          <div className={styles.fieldList}>
+            <InputRow
+              id="call-volume"
+              field="callVolume"
+              label="Google LSA calls"
+              description="Average calls in one month."
+              value={result.callVolume}
+              min={10}
+              max={500}
+              step={5}
+              unit="calls"
+              onChange={update}
+            />
+            <InputRow
+              id="cost-per-call"
+              field="costPerCall"
+              label="Cost per call"
+              description="What Google charges, not your case value."
+              value={result.costPerCall}
+              min={5}
+              max={150}
+              step={1}
+              prefix="$"
+              onChange={update}
+            />
+            <InputRow
+              id="serious-rate"
+              field="seriousRate"
+              label="Serious-inquiry rate"
+              description="The share your firm would genuinely want to work."
+              value={result.seriousRate}
+              min={1}
+              max={80}
+              step={1}
+              unit="%"
+              featured
+              onChange={update}
+            />
+
+            <details className={styles.details}>
+              <summary>
+                Refine the staff-time estimate <span aria-hidden="true">+</span>
+              </summary>
+              <div className={styles.detailsBody}>
+                <InputRow
+                  id="average-minutes"
+                  field="averageMinutes"
+                  label="Minutes per non-serious call"
+                  description="Include notes and follow-up."
+                  value={result.averageMinutes}
+                  min={1}
+                  max={45}
+                  step={1}
+                  unit="min"
+                  onChange={update}
+                />
+                <InputRow
+                  id="hourly-cost"
+                  field="hourlyCost"
+                  label="Loaded paralegal cost"
+                  description="Hourly wage plus payroll burden."
+                  value={result.hourlyCost}
+                  min={15}
+                  max={100}
+                  step={1}
+                  prefix="$"
+                  unit="/hr"
+                  onChange={update}
+                />
+              </div>
+            </details>
+          </div>
+        </form>
+
+        <aside className={styles.resultsPanel} aria-live="polite" aria-atomic="true">
+          <div className={styles.resultHeading}>
+            <p className={styles.overline}>Your monthly intake leak</p>
+            <span className={styles.livePill}><i aria-hidden="true" /> Live estimate</span>
+          </div>
+
+          <div className={styles.primaryResult}>
+            <span className={styles.currencyMark}>$</span>
+            <strong data-testid="monthly-leak">{integer.format(result.monthlyLeak)}</strong>
+            <span className={styles.cadence}>/ month</span>
+          </div>
+          <p className={styles.resultDefinition}>
+            Ad spend tied to non-serious calls, plus the staff time used to handle them.
+          </p>
+
+          <div className={styles.resultGrid}>
+            <div className={styles.metric}>
+              <span>LSA spend on non-serious calls</span>
+              <strong>{currency.format(result.nonSeriousAdSpend)}</strong>
+            </div>
+            <div className={styles.metric}>
+              <span>Paralegal time absorbed</span>
+              <strong>{oneDecimal.format(result.staffHours)} hrs</strong>
+            </div>
+            <div className={styles.metric}>
+              <span>Non-serious calls</span>
+              <strong>{integer.format(result.nonSeriousCalls)}</strong>
+            </div>
+            <div className={styles.metric}>
+              <span>Cost per serious inquiry</span>
+              <strong>
+                {result.costPerSeriousInquiry === null
+                  ? "No serious inquiries"
+                  : currency.format(result.costPerSeriousInquiry)}
+              </strong>
+            </div>
+          </div>
+
+          <div className={styles.annualLine}>
+            <span>Annualized operating leak</span>
+            <strong>{currency.format(result.annualLeak)}</strong>
+          </div>
+          <p className={styles.resultNote}>
+            {result.callsPerSeriousInquiry === null
+              ? "At 0%, the model has no serious inquiries to price."
+              : `At this rate, one serious inquiry takes ${oneDecimal.format(result.callsPerSeriousInquiry)} LSA calls.`}
+          </p>
+        </aside>
+      </section>
+
+      <section className={styles.prescription} aria-labelledby="triage-heading">
+        <div className={styles.prescriptionHeading}>
+          <span className={styles.stepNumber}>02</span>
+          <div>
+            <p className={styles.overline}>Do not move the leak</p>
+            <h2 id="triage-heading">Screen with software.<br />Work the maybes with judgment.</h2>
+          </div>
+        </div>
+        <div className={styles.layers}>
+          <article>
+            <span>Layer 01</span>
+            <h3>Filter the obvious noise</h3>
+            <p>
+              Use automation for practice-area fit, jurisdiction, conflict checks, timing, and the questions that do
+              not require legal judgment.
+            </p>
+          </article>
+          <article>
+            <span>Layer 02</span>
+            <h3>Give the maybes to a person</h3>
+            <p>
+              A trained paralegal catches urgency, ambiguity, and the serious caller who does not sound polished on
+              the first pass.
+            </p>
+          </article>
+        </div>
+        <div className={styles.ctaBand}>
+          <div>
+            <span>Your leak is now visible.</span>
+            <strong>Build the team that closes it.</strong>
+          </div>
+          <Link href="/paralegals" onClick={trackCta}>
+            See Counterbench Paralegal Teams <span aria-hidden="true">→</span>
+          </Link>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/lib/intake-leak-calculator.ts
+++ b/lib/intake-leak-calculator.ts
@@ -1,0 +1,73 @@
+export const INTAKE_LEAK_DEFAULTS = {
+  callVolume: 120,
+  costPerCall: 30,
+  seriousRate: 12,
+  averageMinutes: 9,
+  hourlyCost: 32,
+} as const;
+
+export interface IntakeLeakInput {
+  callVolume?: number | string;
+  costPerCall?: number | string;
+  seriousRate?: number | string;
+  averageMinutes?: number | string;
+  hourlyCost?: number | string;
+}
+
+export interface IntakeLeakResult {
+  callVolume: number;
+  costPerCall: number;
+  seriousRate: number;
+  averageMinutes: number;
+  hourlyCost: number;
+  seriousCalls: number;
+  nonSeriousCalls: number;
+  monthlyLsaSpend: number;
+  nonSeriousAdSpend: number;
+  staffHours: number;
+  staffCost: number;
+  monthlyLeak: number;
+  annualLeak: number;
+  callsPerSeriousInquiry: number | null;
+  costPerSeriousInquiry: number | null;
+}
+
+function clamp(value: number | string | undefined, minimum: number, maximum: number): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return minimum;
+  return Math.min(maximum, Math.max(minimum, numeric));
+}
+
+export function calculateIntakeLeak(input: IntakeLeakInput = {}): IntakeLeakResult {
+  const callVolume = clamp(input.callVolume ?? INTAKE_LEAK_DEFAULTS.callVolume, 0, 100_000);
+  const costPerCall = clamp(input.costPerCall ?? INTAKE_LEAK_DEFAULTS.costPerCall, 0, 10_000);
+  const seriousRate = clamp(input.seriousRate ?? INTAKE_LEAK_DEFAULTS.seriousRate, 0, 100);
+  const averageMinutes = clamp(input.averageMinutes ?? INTAKE_LEAK_DEFAULTS.averageMinutes, 0, 480);
+  const hourlyCost = clamp(input.hourlyCost ?? INTAKE_LEAK_DEFAULTS.hourlyCost, 0, 1_000);
+
+  const seriousCalls = callVolume * (seriousRate / 100);
+  const nonSeriousCalls = callVolume - seriousCalls;
+  const monthlyLsaSpend = callVolume * costPerCall;
+  const nonSeriousAdSpend = nonSeriousCalls * costPerCall;
+  const staffHours = (nonSeriousCalls * averageMinutes) / 60;
+  const staffCost = staffHours * hourlyCost;
+  const monthlyLeak = nonSeriousAdSpend + staffCost;
+
+  return {
+    callVolume,
+    costPerCall,
+    seriousRate,
+    averageMinutes,
+    hourlyCost,
+    seriousCalls,
+    nonSeriousCalls,
+    monthlyLsaSpend,
+    nonSeriousAdSpend,
+    staffHours,
+    staffCost,
+    monthlyLeak,
+    annualLeak: monthlyLeak * 12,
+    callsPerSeriousInquiry: seriousCalls > 0 ? callVolume / seriousCalls : null,
+    costPerSeriousInquiry: seriousCalls > 0 ? monthlyLsaSpend / seriousCalls : null,
+  };
+}

--- a/tests/e2e/intake-leak-calculator.spec.ts
+++ b/tests/e2e/intake-leak-calculator.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Intake Leak Calculator", () => {
+  test("recalculates the intake leak and routes to Paralegal Teams", async ({ page }) => {
+    await page.goto("/tools/intake-leak-calculator");
+
+    await expect(page.getByRole("heading", { name: /your phones are busy/i })).toBeVisible();
+    await expect(page.getByTestId("monthly-leak")).toHaveText("3,675");
+    await expect(page.getByText("15.8 hrs")).toBeVisible();
+
+    await page.getByLabel("Serious-inquiry rate", { exact: true }).fill("20");
+    await expect(page.getByTestId("monthly-leak")).toHaveText("3,341");
+    await expect(page.getByText("14.4 hrs")).toBeVisible();
+
+    const cta = page.getByRole("link", { name: /see counterbench paralegal teams/i });
+    await expect(cta).toHaveAttribute("href", "/paralegals");
+  });
+});


### PR DESCRIPTION
## What

- adds a native `/tools/intake-leak-calculator` route
- calculates non-serious LSA spend, absorbed paralegal hours, staff handling cost, monthly leak, annualized leak, and cost per serious inquiry
- routes firms to Counterbench Paralegal Teams with tool-view and CTA analytics
- adds SoftwareApplication + FAQ structured data and the route to the sitemap
- adds deterministic unit coverage and a browser interaction test

## Why

Small firms often treat intake as a phone-tool problem when the real leak is triage: obvious noise needs automation, while ambiguous inquiries still need trained judgment. This tool makes the operating cost visible before presenting the screening-plus-Paralegal-Teams fix.

## Impact

A new free lead-generation tool for firms buying Google Local Services Ads, with no form submission or signup. All estimates run in the browser from the visitor's assumptions.

## Checks

- `npm run typecheck` — pass
- `npx vitest run __tests__` — 48 passed
- changed-file lint — pass
- `npm run build` — pass
- `npm run e2e` — 16 passed, 3 opt-in visual tests skipped
- desktop + 375px mobile screenshots — reviewed
- full `npm run lint` — existing failures in workshop pages and `LegalDataSourceFinder.tsx`; no lint errors in this change